### PR TITLE
Specify maximum version of Sphinx

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ test =
     pytest-doctestplus
     pytest-cov
 docs =
-    sphinx
+    sphinx <= 2.4.4
     sphinx-automodapi
 
 [options.package_data]


### PR DESCRIPTION
The problems building the documentation is probably from an incompatibility that I've run into before with Sphinx 3.0.0 and more recent not be compatible with the way things are being done here.