### PR TITLE
Expand test performed by GitHub Actions

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -33,6 +33,11 @@ jobs:
             python: 3.7
             toxenv: py37-astropydev
 
+          - name: Python 3.9 with SunPy dev
+            os: ubuntu-latest
+            python: 3.9
+            toxenv: py39-sunpydev
+
           - name: Python 3.8 with code coverage
             os: ubuntu-latest
             python: 3.8

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -3,34 +3,124 @@ name: CI
 on:
   push:
     branches:
-      - main
+      - master
+      - v0.*.x
+    tags:
+      - "v*"
   pull_request:
 
 jobs:
-  build:
-
-    runs-on: ubuntu-latest
+  tests:
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
-        python-version: [3.7, 3.8]
+        include:
+
+          - name: Python 3.7 with minimal dependencies
+            os: ubuntu-latest
+            python: 3.7
+            toxenv: py37-minimal
+
+          - name: Python 3.7
+            os: ubuntu-latest
+            python: 3.7
+            toxenv: py37
+
+          - name: Python 3.7 with Astropy dev
+            os: ubuntu-latest
+            python: 3.7
+            toxenv: py37-astropydev
+
+          - name: Python 3.8 with code coverage
+            os: ubuntu-latest
+            python: 3.8
+            toxenv: py38-cov
+
+          - name: Python 3.8 with Numpy dev
+            os: ubuntu-latest
+            python: 3.8
+            toxenv: py38-numpydev
+
+          - name: Python 3.9
+            os: ubuntu-latest
+            python: 3.9
+            toxenv: py39
+
+          - name: Python 3.9 (Windows)
+            os: windows-latest
+            python: 3.9
+            toxenv: py39
+            toxposargs: --durations=50
+
+          - name: Python 3.8 (MacOS X)
+            os: macos-latest
+            python: 3.8
+            toxenv: py38
+
+          - name: Documentation
+            os: ubuntu-latest
+            python: 3.9
+            toxenv: build_docs
+
+          - name: Linters
+            os: ubuntu-latest
+            python: 3.9
+            toxenv: linters
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
+    - name: Checkout code
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
+        python-version: ${{ matrix.python }}
+    - name: Install Python dependencies
+      run: python -m pip install --upgrade tox codecov
+    - name: Install language-pack-fr and tzdata
+      if: startsWith(matrix.name, 'Documentation')
+      run: sudo apt-get install graphviz pandoc
+    - name: Run tests
+      run: tox ${{ matrix.toxargs }} -e ${{ matrix.toxenv }} -- ${{ matrix.toxposargs }}
+    - name: Upload coverage to codecov
+      if: ${{ contains(matrix.toxenv,'-cov') }}
+      uses: codecov/codecov-action@v1
+      with:
+        file: ./coverage.xml
+  build-n-publish:
+    name: Packaging
+    runs-on: ubuntu-18.04
+    needs: tests
+    steps:
+    - uses: actions/checkout@master
+    - name: Get history and tags for SCM versioning to work
       run: |
-        python -m pip install --upgrade pip
-        pip install flake8 pytest pytest-doctestplus
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-    - name: Lint with flake8
+        git fetch --prune --unshallow
+        git fetch --depth=1 origin +refs/tags/*:refs/tags/*
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.7
+    - name: Install requirements
       run: |
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-    - name: Test with pytest
+        pip install --upgrade pip
+        pip install setuptools numpy wheel setuptools_scm twine
+    - name: Build a binary wheel
+      run: python setup.py bdist_wheel
+    - name: Build a source tarball
+      run: python setup.py sdist
+    - name: Twine check
+      run: twine check dist/*
+    - name: Install PlasmaPy in all variants
       run: |
-        pytest
+        pip install --progress-bar off .[all,dev]
+        pip install -e .[all,dev]
+        python setup.py develop
+    - name: Publish distribution, if tagged, 📦 to PyPI
+      if: ${{ startsWith(github.ref, 'refs/tags') && !endsWith(github.ref, 'dev') }}
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        password: ${{ secrets.pypi_access_token }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,3 +5,7 @@ requires = ["setuptools",
             "wheel"]
 
 build-backend = 'setuptools.build_meta'
+
+[ tool.gilesbot ]
+  [ tool.gilesbot.pull_requests ]
+    enabled = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,10 +51,18 @@ docs =
 xrtpy = data/*
 
 [tool:pytest]
+minversion = 5.1
 testpaths = "xrtpy" "docs"
-doctest_plus = enabled
-text_file_format = rst
-addopts = --doctest-rst
+norecursedirs = "build" "docs/_build" "examples" "auto_examples"
+doctest_optionflags =
+    NORMALIZE_WHITESPACE
+    ELLIPSIS
+    NUMBER
+addopts = --doctest-modules --doctest-continue-on-failure --ignore=docs/conf.py
+filterwarnings =
+    ignore:.*Creating a LegacyVersion.*:DeprecationWarning
+looponfailroots =
+    xrtpy
 
 [coverage:run]
 omit =

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,6 +43,7 @@ test =
     pytest
     pytest-doctestplus
     pytest-cov
+    pytest-xdist
 docs =
     sphinx <= 2.4.4
     sphinx-automodapi

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,7 +43,6 @@ test =
     pytest
     pytest-doctestplus
     pytest-cov
-    pytest-xdist
 docs =
     sphinx <= 2.4.4
     sphinx-automodapi

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,8 @@ except Exception:
 """.lstrip()
 
 setup(
-    use_scm_version={'write_to': os.path.join('xrtpy', 'version.py'),
-                     'write_to_template': VERSION_TEMPLATE},
-
+    use_scm_version={
+        "write_to": os.path.join("xrtpy", "version.py"),
+        "write_to_template": VERSION_TEMPLATE,
+    },
 )

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ whitelist_externals=
 setenv =
     MPLBACKEND = agg
     COLUMNS = 180
-    PYTEST_COMMAND = pytest --pyargs xrtpy --durations=25 {toxinidir}{/}docs -n=auto --dist=loadfile --ignore={toxinidir}{/}docs{/}conf.py
+    PYTEST_COMMAND = pytest --pyargs xrtpy --durations=25 {toxinidir}{/}docs --ignore={toxinidir}{/}docs{/}conf.py
 extras = tests
 deps =
     numpydev: git+https://github.com/numpy/numpy

--- a/tox.ini
+++ b/tox.ini
@@ -36,7 +36,6 @@ commands = coverage erase
 [testenv:build_docs]
 changedir = {toxinidir}
 extras = docs
-deps = pytest-doctestplus
 setenv =
     HOME = {envtmpdir}
 commands = sphinx-build docs docs{/}_build{/}html -W -b html

--- a/tox.ini
+++ b/tox.ini
@@ -1,45 +1,79 @@
 [tox]
-envlist =
-    py{37,38}-test
-    build_docs
-    codestyle
-isolated_build = true
-# This is included for testing of the template. You can remove it safely.
-skip_missing_interpreters = True
+envlist = clean,py37,build_docs
+isolated_build = True
 
 [testenv]
-# Pass through the following environemnt variables which may be needed for the CI
-passenv = HOME WINDIR LC_ALL LC_CTYPE CC CI TRAVIS
+whitelist_externals=
+    /bin/bash
+    /usr/bin/bash
+setenv =
+    MPLBACKEND = agg
+    COLUMNS = 180
+    PYTEST_COMMAND = pytest --pyargs xrtpy --durations=25 {toxinidir}{/}docs -n=auto --dist=loadfile --ignore={toxinidir}{/}docs{/}conf.py
+extras = tests
+deps =
+    numpydev: git+https://github.com/numpy/numpy
+    astropydev: git+https://github.com/astropy/astropy
+    sunpydev: git+https://github.com/sunpy/sunpy
+    cov: pytest-cov
+    pytest-github-actions-annotate-failures
+commands =
+    cov: {env:PYTEST_COMMAND} {posargs} --cov=xrtpy --cov-report=xml --cov-config={toxinidir}{/}setup.cfg --cov-append --cov-report xml:coverage.xml
 
-# Run the tests in a temporary directory to make sure that we don't import
-# the package from the source tree
-changedir = .tmp/{envname}
-
-# tox environments are constructued with so-called 'factors' (or terms)
-# separated by hyphens, e.g. test-devdeps-cov. Lines below starting with factor:
-# will only take effect if that factor is included in the environment name. To
-# see a list of example environments that can be run, along with a description,
-# run:
-#
-#     tox -l -v
-#
 description =
     run tests
+    numpydev: with the git main version of numpy
+    astropydev: with the git main version of astropy
+    sunpydev: with the git main version of sunpy
+    minimal: with minimal versions of dependencies
+    cov: with code coverage
 
-deps =
-# The following indicates which extras_require from setup.cfg will be installed
-extras =
-    test
-    alldeps: all
-
-commands =
-    pip freeze
-    pytest --pyargs xrtpy {toxinidir}/docs --cov xrtpy --cov-config={toxinidir}/setup.cfg {posargs}
+[testenv:clean]
+deps = coverage
+skip_install = true
+commands = coverage erase
 
 [testenv:build_docs]
-changedir = docs
-description = invoke sphinx-build to build the HTML docs
+changedir = {toxinidir}
 extras = docs
+setenv =
+    HOME = {envtmpdir}
+commands = sphinx-build docs docs{/}_build{/}html -W -b html
+
+[testenv:build_docs_no_examples]
+changedir = {toxinidir}
+extras = docs
+setenv =
+    HOME = {envtmpdir}
+commands = sphinx-build -D nbsphinx_execute='never' docs docs{/}_build{/}html -b html
+
+# This env tests minimal versions of each dependency.
+[testenv:py37-minimal]
+basepython = python3.7
+extras =
+deps =
+  pytest-cov
+  numpy==1.17.0
+  astropy==4.2
+  pytest==6.2.4
+  sunpy==2.0
+  pillow
+
+setenv =
+    PYTEST_COMMAND = pytest --pyargs xrtpy --durations=25 {toxinidir}{/}docs --ignore={toxinidir}{/}docs{/}conf.py
+
+[testenv:linters]
+deps =
+    flake8
+    pydocstyle
+    flake8-rst-docstrings
+    pygments
 commands =
-    pip freeze
-    sphinx-build -W -b html . _build/html {posargs}
+    flake8 --bug-report
+    flake8 {toxinidir}{/}xrtpy --count --show-source --statistics
+
+[testenv:py37-minimal-pypi-import]
+basepython = python3.7
+extras =
+deps =
+commands = python -c 'import xrtpy'

--- a/tox.ini
+++ b/tox.ini
@@ -36,16 +36,10 @@ commands = coverage erase
 [testenv:build_docs]
 changedir = {toxinidir}
 extras = docs
+deps = pytest-doctestplus
 setenv =
     HOME = {envtmpdir}
 commands = sphinx-build docs docs{/}_build{/}html -W -b html
-
-[testenv:build_docs_no_examples]
-changedir = {toxinidir}
-extras = docs
-setenv =
-    HOME = {envtmpdir}
-commands = sphinx-build -D nbsphinx_execute='never' docs docs{/}_build{/}html -b html
 
 # This env tests minimal versions of each dependency.
 [testenv:py37-minimal]


### PR DESCRIPTION
This pull request experiments with using versions of `tox.ini` and `testing.yml` that were modified from how they were set up in PlasmaPy.  If this doesn't work then I'll look into this more closely.

The PlasmaPy license is being added separately in #16 but would need to be included if this PR is merged.

Closes #7