### PR TITLE
Reconfigure tests and require Python ≥ 3.8 and NumPy ≥ 1.19

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -39,21 +39,6 @@ jobs:
             python: 3.9
             toxenv: py39-cov
 
-            - name: Python 3.8 with Astropy dev
-            os: ubuntu-latest
-            python: 3.8
-            toxenv: py38-astropydev
-
-          - name: Python 3.9 with SunPy dev
-            os: ubuntu-latest
-            python: 3.9
-            toxenv: py39-sunpydev
-
-          - name: Python 3.8 with Numpy dev
-            os: ubuntu-latest
-            python: 3.8
-            toxenv: py38-numpydev
-
           - name: Documentation
             os: ubuntu-latest
             python: 3.9

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   push:
     branches:
-      - master
+      - main
       - v0.*.x
     tags:
       - "v*"
@@ -18,15 +18,15 @@ jobs:
       matrix:
         include:
 
-          - name: Python 3.8 with minimal dependencies
-            os: windows-latest
-            python: 3.8
-            toxenv: py38-minimal
-
           - name: Python 3.8 (MacOS X)
             os: macos-latest
             python: 3.8
             toxenv: py38
+
+          - name: Python 3.8 with minimal dependencies
+            os: windows-latest
+            python: 3.8
+            toxenv: py38-minimal
 
          - name: Python 3.9 (Windows)
             os: windows-latest

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -29,7 +29,7 @@ jobs:
             python: 3.8
             toxenv: py38-minimal
 
-         - name: Python 3.9 (Windows)
+          - name: Python 3.9 (Windows)
             os: windows-latest
             python: 3.9
             toxenv: py39

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -8,6 +8,7 @@ on:
     tags:
       - "v*"
   pull_request:
+  workflow_dispatch:
 
 jobs:
   tests:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -18,51 +18,41 @@ jobs:
       matrix:
         include:
 
-          - name: Python 3.7 with minimal dependencies
-            os: ubuntu-latest
-            python: 3.7
-            toxenv: py37-minimal
+          - name: Python 3.8 with minimal dependencies
+            os: windows-latest
+            python: 3.8
+            toxenv: py38-minimal
 
-          - name: Python 3.7
-            os: ubuntu-latest
-            python: 3.7
-            toxenv: py37
+          - name: Python 3.8 (MacOS X)
+            os: macos-latest
+            python: 3.8
+            toxenv: py38
 
-          - name: Python 3.7 with Astropy dev
+         - name: Python 3.9 (Windows)
+            os: windows-latest
+            python: 3.9
+            toxenv: py39
+            toxposargs: --durations=50
+
+          - name: Python 3.9 with code coverage
             os: ubuntu-latest
-            python: 3.7
-            toxenv: py37-astropydev
+            python: 3.9
+            toxenv: py39-cov
+
+            - name: Python 3.8 with Astropy dev
+            os: ubuntu-latest
+            python: 3.8
+            toxenv: py38-astropydev
 
           - name: Python 3.9 with SunPy dev
             os: ubuntu-latest
             python: 3.9
             toxenv: py39-sunpydev
 
-          - name: Python 3.8 with code coverage
-            os: ubuntu-latest
-            python: 3.8
-            toxenv: py38-cov
-
           - name: Python 3.8 with Numpy dev
             os: ubuntu-latest
             python: 3.8
             toxenv: py38-numpydev
-
-          - name: Python 3.9
-            os: ubuntu-latest
-            python: 3.9
-            toxenv: py39
-
-          - name: Python 3.9 (Windows)
-            os: windows-latest
-            python: 3.9
-            toxenv: py39
-            toxposargs: --durations=50
-
-          - name: Python 3.8 (MacOS X)
-            os: macos-latest
-            python: 3.8
-            toxenv: py38
 
           - name: Documentation
             os: ubuntu-latest

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -1,0 +1,59 @@
+name: weekly tests
+
+on:
+  schedule:
+  - cron: 17 7 * * 1
+  workflow_dispatch:
+
+jobs:
+  tests:
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+
+        - name: Python 3.8 with Astropy dev
+          os: ubuntu-latest
+          python: 3.8
+          toxenv: py38-astropydev
+
+        - name: Python 3.8 with NumPy dev
+          os: ubuntu-latest
+          python: 3.8
+          toxenv: py38-numpydev
+
+        - name: Python 3.8 with sunpy dev
+          os: ubuntu-latest
+          python: 3.8
+          toxenv: py38-sunpydev
+
+        - name: Documentation with Sphinx dev
+          os: ubuntu-latest
+          python: 3.8
+          toxenv: build_docs-sphinxdev
+          toxposargs: -q
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2.3.5
+      with:
+        fetch-depth: 0
+    - name: Set up Python
+      uses: actions/setup-python@v2.2.2
+      with:
+        python-version: ${{ matrix.python }}
+    - name: Install Python dependencies
+      run: python -m pip install --upgrade tox codecov
+    - name: Install language-pack-fr and tzdata
+      if: startsWith(matrix.name, 'Documentation')
+      run: sudo apt-get install graphviz pandoc
+    - name: Run tests
+      run: tox ${{ matrix.toxargs }} -e ${{ matrix.toxenv }} -- ${{ matrix.toxposargs }}
+    - name: Upload coverage to codecov
+      if: ${{ contains(matrix.toxenv,'-cov') }}
+      uses: codecov/codecov-action@v2.1.0
+      with:
+        file: ./coverage.xml

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,7 +3,7 @@ version: 2
 formats: all
 
 python:
-  version: 3.9
+  version: 3.8
   install:
     - requirements: docs/requirements.txt
     - method: setuptools

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,7 +3,7 @@ version: 2
 formats: all
 
 python:
-  version: 3.7
+  version: 3.9
   install:
     - requirements: docs/requirements.txt
     - method: setuptools

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,7 +5,8 @@ include setup.py
 include LICENSE
 include pyproject.toml
 
-recursive-include xrtpy *.pyx *.c *.pxd *.genx *.geny *.json
+recursive-include xrtpy *.pyx *.c *.pxd *.json
+recursive-include xrtpy/data *.genx *.geny *.txt
 recursive-include docs *
 recursive-include licenses *
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,6 +5,7 @@ pillow
 sphinx == 2.4.4
 sphinx-automodapi
 sphinx-gallery
-sphinx_rtd_theme
+sphinx_rtd_theme >= 1.0.0
+docutils >= 0.17.1
 pytest
 setuptools-scm

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,7 +2,7 @@
 
 numpydoc
 pillow
-sphinx == 2.4.4
+sphinx >= 2.4.4
 sphinx-automodapi
 sphinx-gallery
 sphinx_rtd_theme >= 1.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,8 @@
 [build-system]
 
-requires = ["setuptools",
+requires = ["setuptools >= 41.2",
             "setuptools_scm",
-            "wheel"]
+            "wheel >= 0.29.0"]
 
 build-backend = 'setuptools.build_meta'
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-numpy >= 1.17
+numpy >= 1.19
 astropy >= 4.2
 sunpy >= 2.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,7 @@ test =
     pytest-doctestplus
     pytest-cov
 docs =
-    sphinx <= 2.4.4
+    sphinx >= 2.4.4
     sphinx-automodapi
 
 [options.package_data]

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,6 @@ classifiers =
     License :: OSI Approved :: BSD License
     Operating System :: OS Independent
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: Implementation :: CPython
@@ -26,10 +25,10 @@ classifiers =
 [options]
 zip_safe = False
 packages = find:
-python_requires = >=3.7
+python_requires = >=3.8
 setup_requires = setuptools_scm
 install_requires =
-    numpy >= 1.17
+    numpy >= 1.19
     astropy >= 4.2
     sunpy >= 2.0
 

--- a/tox.ini
+++ b/tox.ini
@@ -38,7 +38,7 @@ changedir = {toxinidir}
 extras = docs
 setenv =
     HOME = {envtmpdir}
-commands = sphinx-build docs docs{/}_build{/}html -W -b html
+commands = sphinx-build docs docs{/}_build{/}html -W -n --keep-going -b html {posargs}
 
 # This env tests minimal versions of each dependency.
 [testenv:py38-minimal]
@@ -58,9 +58,12 @@ setenv =
 [testenv:linters]
 deps =
     flake8
+    flake8-absolute-import
     pydocstyle
     flake8-rst-docstrings
+    flake8-use-fstring
     pygments
+    dlint
 commands =
     flake8 --bug-report
     flake8 {toxinidir}{/}xrtpy --count --show-source --statistics

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = clean,py37,build_docs
+envlist = clean,py38,build_docs
 isolated_build = True
 
 [testenv]
@@ -41,12 +41,12 @@ setenv =
 commands = sphinx-build docs docs{/}_build{/}html -W -b html
 
 # This env tests minimal versions of each dependency.
-[testenv:py37-minimal]
-basepython = python3.7
+[testenv:py38-minimal]
+basepython = python3.8
 extras =
 deps =
   pytest-cov
-  numpy==1.17.0
+  numpy==1.19.0
   astropy==4.2
   pytest==6.2.4
   sunpy==2.0
@@ -65,8 +65,8 @@ commands =
     flake8 --bug-report
     flake8 {toxinidir}{/}xrtpy --count --show-source --statistics
 
-[testenv:py37-minimal-pypi-import]
-basepython = python3.7
+[testenv:py38-minimal-pypi-import]
+basepython = python3.8
 extras =
 deps =
 commands = python -c 'import xrtpy'

--- a/tox.ini
+++ b/tox.ini
@@ -12,8 +12,9 @@ setenv =
     PYTEST_COMMAND = pytest --pyargs xrtpy --durations=25 {toxinidir}{/}docs --ignore={toxinidir}{/}docs{/}conf.py
 extras = tests
 deps =
-    numpydev: git+https://github.com/numpy/numpy
     astropydev: git+https://github.com/astropy/astropy
+    numpydev: git+https://github.com/numpy/numpy
+    sphinxdev: git+https://github.com/sphinx-doc/sphinx
     sunpydev: git+https://github.com/sunpy/sunpy
     cov: pytest-cov
     pytest-github-actions-annotate-failures
@@ -22,10 +23,10 @@ commands =
 
 description =
     run tests
-    numpydev: with the git main version of numpy
-    astropydev: with the git main version of astropy
-    sunpydev: with the git main version of sunpy
-    sphinxdev: git+https://github.com/sphinx-doc/sphinx
+    astropydev: with the development version of astropy
+    numpydev: with the development version of numpy
+    sphinxdev: with the development version of Sphinx
+    sunpydev: with the development version of sunpy
     minimal: with minimal versions of dependencies
     cov: with code coverage
 

--- a/tox.ini
+++ b/tox.ini
@@ -25,6 +25,7 @@ description =
     numpydev: with the git main version of numpy
     astropydev: with the git main version of astropy
     sunpydev: with the git main version of sunpy
+    sphinxdev: git+https://github.com/sphinx-doc/sphinx
     minimal: with minimal versions of dependencies
     cov: with code coverage
 


### PR DESCRIPTION
Following the recommended schedule in [NEP 29](https://numpy.org/neps/nep-0029-deprecation_policy.html#), this pull request drops support for Python 3.7 and some older versions of NumPy.  I'm also updating the test configuration, and will probably switch some of these tests to weekly rather than having them run on every pull request.