### PR TITLE
Reorganize package requirements

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -3,14 +3,15 @@ name: CI
 on:
   push:
     branches:
-      - main
-      - v0.*.x
+    - main
+    - v0.*.x
     tags:
-      - "v*"
+    - v*
   pull_request:
+  workflow_dispatch:
 
 jobs:
-  tests:
+  initial-tests:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
     strategy:
@@ -18,45 +19,19 @@ jobs:
       matrix:
         include:
 
-          - name: Python 3.10
-            os: ubuntu-latest
-            python: '3.10'
-            toxenv: py310
+        - name: Python 3.10
+          os: ubuntu-latest
+          python: '3.10'
+          toxenv: py310
 
-          - name: Python 3.8 with minimal dependencies
-            os: ubuntu-latest
-            python: 3.8
-            toxenv: py38-minimal
-
-          - name: Python 3.9
-            os: ubuntu-latest
-            python: 3.9
-            toxenv: py39
-
-          - name: Python 3.9 (Windows)
-            os: windows-latest
-            python: 3.9
-            toxenv: py39
-            toxposargs: --durations=50
-
-          - name: Python 3.8 (MacOS X)
-            os: macos-latest
-            python: 3.8
-            toxenv: py38
-
-          - name: Documentation
-            os: ubuntu-latest
-            python: '3.10'
-            toxenv: build_docs
-
-          - name: Linters
-            os: ubuntu-latest
-            python: 3.9
-            toxenv: linters
+        - name: Linters
+          os: ubuntu-latest
+          python: 3.8
+          toxenv: linters
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0
     - name: Set up Python
@@ -64,7 +39,56 @@ jobs:
       with:
         python-version: ${{ matrix.python }}
     - name: Install Python dependencies
-      run: python -m pip install --upgrade tox codecov
+      run: python -m pip install --progress-bar off --upgrade tox codecov
+    - name: Run tests
+      run: tox ${{ matrix.toxargs }} -e ${{ matrix.toxenv }} -- ${{ matrix.toxposargs }}
+  comprehensive-tests:
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
+    needs: initial-tests
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+
+        - name: Python 3.8 with minimal dependencies
+          os: ubuntu-latest
+          python: 3.8
+          toxenv: py38-all-minimal
+
+        - name: Python 3.8, all tests, code coverage
+          os: ubuntu-latest
+          python: 3.8
+          toxenv: py38-all-cov
+
+        - name: Python 3.8 (Windows)
+          os: windows-latest
+          python: 3.8
+          toxenv: py38-all
+          toxposargs: --durations=50
+
+        - name: Python 3.8 (MacOS X)
+          os: macos-latest
+          python: 3.8
+          toxenv: py38-all
+
+        - name: Python 3.9
+          os: ubuntu-latest
+          python: 3.9
+          toxenv: py39
+
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: Set up Python
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python }}
+    - name: Install Python dependencies
+      run: python -m pip install --progress-bar off --upgrade tox codecov
     - name: Install language-pack-fr and tzdata
       if: startsWith(matrix.name, 'Documentation')
       run: sudo apt-get install graphviz pandoc
@@ -72,27 +96,49 @@ jobs:
       run: tox ${{ matrix.toxargs }} -e ${{ matrix.toxenv }} -- ${{ matrix.toxposargs }}
     - name: Upload coverage to codecov
       if: ${{ contains(matrix.toxenv,'-cov') }}
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v3
       with:
         file: ./coverage.xml
+  documentation:
+    name: Documentation
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: Set up Python
+      uses: actions/setup-python@v3
+      with:
+        python-version: 3.8
+    - name: Install Python dependencies
+      run: python -m pip install --progress-bar off --upgrade tox
+    - name: Install language-pack-fr and tzdata
+      run: sudo apt-get install graphviz pandoc
+    - name: Run tests
+      run: tox  -e build_docs -- -q
   build-n-publish:
     name: Packaging
-    runs-on: ubuntu-latest
-    needs: tests
+    runs-on: ubuntu-18.04
+    needs:
+    - comprehensive-tests
+    - documentation
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v3
     - name: Get history and tags for SCM versioning to work
       run: |
         git fetch --prune --unshallow
         git fetch --depth=1 origin +refs/tags/*:refs/tags/*
-    - name: Set up Python
-      uses: actions/setup-python@v1
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v3
       with:
         python-version: 3.8
     - name: Install requirements
       run: |
-        pip install --upgrade pip
-        pip install setuptools numpy wheel setuptools_scm twine
+        pip install --progress-bar off --upgrade pip
+        pip install --progress-bar off setuptools numpy wheel setuptools_scm twine
     - name: Build a binary wheel
       run: python setup.py bdist_wheel
     - name: Build a source tarball
@@ -102,7 +148,7 @@ jobs:
     - name: Install PlasmaPy in all variants
       run: |
         pip install --progress-bar off .[all,dev]
-        pip install -e .[all,dev]
+        pip install --progress-bar off -e .[all,dev]
         python setup.py develop
     - name: Publish distribution, if tagged, 📦 to PyPI
       if: ${{ startsWith(github.ref, 'refs/tags') && !endsWith(github.ref, 'dev') }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,9 @@
 [build-system]
+requires = ["setuptools >= 50.0",
+            "setuptools_scm >= 6.0",
+            "wheel >= 0.34.0"]  # ought to mirror 'requirements/build.txt'
+build-backend = "setuptools.build_meta"
 
-requires = ["setuptools",
-            "setuptools_scm",
-            "wheel"]
-
-build-backend = 'setuptools.build_meta'
 
 [tool.isort]
 line_length = 88

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,8 @@
-numpy >= 1.20
-astropy >= 4.3.1
-sunpy >= 2.0
+# all dependencies required to build, run, test, and document xrtpy
+# * look to the specific requirements/*.txt for specific needs
+# * this will mimic `pip install xrtpy[developer]` (excluding xrtpy)
+-r requirements/build.txt
+-r requirements/install.txt
+-r requirements/tests.txt
+-r requirements/docs.txt
+-r requirements/extras.txt

--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -2,4 +2,4 @@
 # ought to mirror 'build-system.requires' under in pyproject.toml
 setuptools >= 50.0
 setuptools_scm >= 6.0
-wheel >= 0.29.0
+wheel >= 0.34.0

--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -1,0 +1,5 @@
+# these are dependencies required to build the package distribution for installation
+# ought to mirror 'build-system.requires' under in pyproject.toml
+setuptools >= 50.0
+setuptools_scm >= 6.0
+wheel >= 0.29.0

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,0 +1,20 @@
+# These are dependencies required to build package documentation, and
+# ought to mirror 'docs' under options.extras_require in setup.cfg.
+# This lists the requirements that would be installed when doing:
+# pip install xrtpy[docs]
+-r extras.txt
+-r install.txtx
+docutils < 0.18
+jinja2 < 3.1
+nbsphinx >= 0.8
+numpydoc >= 1.2
+pillow
+pygments >= 2.11.0
+sphinx <= 2.4.4
+sphinx-changelog
+sphinx-copybutton
+sphinx-gallery
+sphinx-hoverxref
+sphinx_rtd_theme >= 1.0.0
+sphinxcontrib-bibtex
+towncrier >= 20.0

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -11,6 +11,7 @@ numpydoc >= 1.2
 pillow
 pygments >= 2.11.0
 sphinx <= 2.4.4
+sphinx_automodapi
 sphinx-changelog
 sphinx-copybutton
 sphinx-gallery

--- a/requirements/extras.txt
+++ b/requirements/extras.txt
@@ -1,0 +1,8 @@
+# These are "extra" dependencies to run advanced package features, and
+# ought to mirror 'extras' under options.extras_require in setup.cfg.
+# This lists the requirements that would be installed when doing:
+# pip install xrtpy[extras]
+-r install.txt
+codespell
+pre-commit
+tox

--- a/requirements/install.txt
+++ b/requirements/install.txt
@@ -1,0 +1,9 @@
+# these are dependencies required to use the package
+# ought to mirror 'install_requires' under 'options' in setup.cfg
+-r build.txt
+astropy >= 4.3.1
+cached-property >= 1.5.2
+matplotlib >= 3.3.0
+numpy >= 1.20.0
+packaging
+scipy >= 1.5.0

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -1,0 +1,14 @@
+# These are dependencies required to run package tests, and
+# ought to mirror 'tests' under options.extras_require in setup.cfg.
+# This lists the requirements that would be installed when doing:
+# pip install xrtpy[tests]
+-r extras.txt
+-r install.txt
+dlint
+flake8
+flake8-absolute-import
+flake8-rst-docstrings
+flake8-use-fstring
+pydocstyle
+pytest >= 5.4.0
+pytest-xdist

--- a/setup.cfg
+++ b/setup.cfg
@@ -63,6 +63,7 @@ docs =
   pillow
   pygments >= 2.11.0
   sphinx <= 2.4.4
+  sphinx_automodapi
   sphinx-changelog
   sphinx-copybutton
   sphinx-gallery

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,17 +11,17 @@ edit_on_github = True
 github_project =
 keywords = solar physics
 classifiers =
-    Development Status :: 1 - Planning
-    Topic :: Scientific/Engineering :: Physics
-    Topic :: Scientific/Engineering :: Astronomy
-    Intended Audience :: Science/Research
-    License :: OSI Approved :: BSD License
-    Operating System :: OS Independent
-    Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.8
-    Programming Language :: Python :: 3.9
-    Programming Language :: Python :: 3.10    
-    Programming Language :: Python :: Implementation :: CPython
+  Development Status :: 1 - Planning
+  Topic :: Scientific/Engineering :: Physics
+  Topic :: Scientific/Engineering :: Astronomy
+  Intended Audience :: Science/Research
+  License :: OSI Approved :: BSD License
+  Operating System :: OS Independent
+  Programming Language :: Python :: 3
+  Programming Language :: Python :: 3.8
+  Programming Language :: Python :: 3.9
+  Programming Language :: Python :: 3.10
+  Programming Language :: Python :: Implementation :: CPython
 
 [options]
 zip_safe = False
@@ -29,25 +29,59 @@ packages = find:
 python_requires = >=3.8
 setup_requires = setuptools_scm
 install_requires =
-    numpy >= 1.20
-    astropy >= 4.3.1
-    sunpy >= 2.0
+  astropy >= 4.3.1
+  cached-property >= 1.5.2
+  matplotlib >= 3.3.0
+  numpy >= 1.20.0
+  packaging
+  scipy >= 1.5.0
 
 [options.extras_require]
-all =
-test =
-    pytest
-    pytest-doctestplus
-    pytest-cov
+extras =
+  # ought to mirror requirements/extras.txt
+  codespell
+  pre-commit
+  tox
+tests =
+  # ought to mirror requirements/tests.txt
+  %(extras)s
+  dlint
+  flake8
+  flake8-absolute-import
+  flake8-rst-docstrings
+  flake8-use-fstring
+  pydocstyle
+  pytest >= 5.4.0
+  pytest-xdist
 docs =
-    sphinx <= 2.4.4
-    sphinx-automodapi
+  # ought to mirror requirements/docs.txt
+  %(extras)s
+  docutils < 0.18
+  jinja2 < 3.1
+  nbsphinx >= 0.8
+  numpydoc >= 1.2
+  pillow
+  pygments >= 2.11.0
+  sphinx <= 2.4.4
+  sphinx-changelog
+  sphinx-copybutton
+  sphinx-gallery
+  sphinx-hoverxref
+  sphinx_rtd_theme >= 1.0.0
+  sphinxcontrib-bibtex
+  towncrier >= 20.0
+developer =
+  # install everything for developers
+  # ought to functionally mirror requirements.txt
+  %(docs)s
+  %(extras)s
+  %(tests)s
 
 [options.package_data]
 xrtpy = data/*
 
 [tool:pytest]
-minversion = 5.1
+minversion = 5.4
 testpaths = "xrtpy" "docs"
 norecursedirs = "build" "docs/_build" "examples" "auto_examples"
 doctest_optionflags =
@@ -59,36 +93,6 @@ filterwarnings =
     ignore:.*Creating a LegacyVersion.*:DeprecationWarning
 looponfailroots =
     xrtpy
-
-[coverage:run]
-omit =
-  xrtpy/__init*
-  xrtpy/conftest.py
-  xrtpy/*setup_package*
-  xrtpy/tests/*
-  xrtpy/*/tests/*
-  xrtpy/extern/*
-  xrtpy/version*
-  */xrtpy/__init*
-  */xrtpy/conftest.py
-  */xrtpy/*setup_package*
-  */xrtpy/tests/*
-  */xrtpy/*/tests/*
-  */xrtpy/extern/*
-  */xrtpy/version*
-
-[coverage:report]
-exclude_lines =
-  # Have to re-enable the standard pragma
-  pragma: no cover
-  # Don't complain about packages we have installed
-  except ImportError
-  # Don't complain about script hooks
-  def main\(.*\):
-  # Ignore branches that don't pertain to this version of Python
-  pragma: py{ignore_python_version}
-  # Don't complain about IPython completion helper
-  def _ipython_key_completions_
 
 [flake8]
 convention = numpy
@@ -118,4 +122,96 @@ exclude =
     docs/conf.py,
     setup.py,
     .jupyter
+# Use rst-roles and rst-directives to list roles and directives from
+# Sphinx and its extensions so that they don't get flagged when using
+# flake8-rst-docstrings.
+rst-roles =
+    abbr
+    any
+    attr
+    cite
+    cite:ct
+    cite:cts
+    cite:p
+    cite:ps
+    cite:t
+    cite:ts
+    class
+    command
+    confval
+    data
+    dfn
+    doc
+    download
+    envvar
+    eq
+    event
+    exc
+    file
+    func
+    guilabel
+    kbd
+    keyword
+    makevar
+    manpage
+    menuselection
+    meth
+    mod
+    numref
+    option
+    pep
+    program
+    ref
+    regexp
+    rst:dir
+    samp
+    term
+    token
+rst-directives =
+    codeauthor
+    confval
+    deprecated
+    event
+    highlight
+    hlist
+    index
+    literalinclude
+    nbgallery
+    only
+    rst:directive
+    sectionauthor
+    seealso
+    tabularcolumns
+    todo
+    versionadded
+    versionchanged
+enable-extensions =
+    # Look for strings that have {} in them but aren't f-strings.
+    # If there is a false positive from this in a file, put that in
+    # per-file-ignores.
+    FS003
 
+[coverage:run]
+omit =
+  ci-helpers/*
+  */tests/*
+  xrtpy.version.py
+
+[coverage:report]
+exclude_lines =
+    coverage: ignore
+    ImportError
+    ModuleNotFoundError
+    @vectorize
+    @numba.vectorize
+    @numba.jit
+    @jit
+    @numba.njit
+    @njit
+
+[codespell]
+skip = .tox,.git,.hypothesis,_build,__pycache__,*egg*,*.png,*.genx,*.geny
+# Occasionally codespell will have false positives. Put words here that
+# should be ignored when codespell checks spellings.
+ignore-words-list =
+   circularly

--- a/setup.cfg
+++ b/setup.cfg
@@ -85,111 +85,111 @@ minversion = 5.4
 testpaths = "xrtpy" "docs"
 norecursedirs = "build" "docs/_build" "examples" "auto_examples"
 doctest_optionflags =
-    NORMALIZE_WHITESPACE
-    ELLIPSIS
-    NUMBER
+  NORMALIZE_WHITESPACE
+  ELLIPSIS
+  NUMBER
 addopts = --doctest-modules --doctest-continue-on-failure --ignore=docs/conf.py
 filterwarnings =
-    ignore:.*Creating a LegacyVersion.*:DeprecationWarning
+  ignore:.*Creating a LegacyVersion.*:DeprecationWarning
 looponfailroots =
-    xrtpy
+  xrtpy
 
 [flake8]
 convention = numpy
 extend-ignore =
-    D105,
-    D107,
-    D202,
-    D205,
-    D302,
-    D400,
-    D403,
-    E203,
-    E501,
-    E731,
-    F401,
-    F405,
-    W605,
-    RST210,
-    RST213,
-    RST306
+  D105,
+  D107,
+  D202,
+  D205,
+  D302,
+  D400,
+  D403,
+  E203,
+  E501,
+  E731,
+  F401,
+  F405,
+  W605,
+  RST210,
+  RST213,
+  RST306
 exclude =
-    extern,
-    sphinx,
-    *test*,
-    *parsetab.py,
-    conftest.py,
-    docs/conf.py,
-    setup.py,
-    .jupyter
+  extern,
+  sphinx,
+  *test*,
+  *parsetab.py,
+  conftest.py,
+  docs/conf.py,
+  setup.py,
+  .jupyter
 # Use rst-roles and rst-directives to list roles and directives from
 # Sphinx and its extensions so that they don't get flagged when using
 # flake8-rst-docstrings.
 rst-roles =
-    abbr
-    any
-    attr
-    cite
-    cite:ct
-    cite:cts
-    cite:p
-    cite:ps
-    cite:t
-    cite:ts
-    class
-    command
-    confval
-    data
-    dfn
-    doc
-    download
-    envvar
-    eq
-    event
-    exc
-    file
-    func
-    guilabel
-    kbd
-    keyword
-    makevar
-    manpage
-    menuselection
-    meth
-    mod
-    numref
-    option
-    pep
-    program
-    ref
-    regexp
-    rst:dir
-    samp
-    term
-    token
+  abbr
+  any
+  attr
+  cite
+  cite:ct
+  cite:cts
+  cite:p
+  cite:ps
+  cite:t
+  cite:ts
+  class
+  command
+  confval
+  data
+  dfn
+  doc
+  download
+  envvar
+  eq
+  event
+  exc
+  file
+  func
+  guilabel
+  kbd
+  keyword
+  makevar
+  manpage
+  menuselection
+  meth
+  mod
+  numref
+  option
+  pep
+  program
+  ref
+  regexp
+  rst:dir
+  samp
+  term
+  token
 rst-directives =
-    codeauthor
-    confval
-    deprecated
-    event
-    highlight
-    hlist
-    index
-    literalinclude
-    nbgallery
-    only
-    rst:directive
-    sectionauthor
-    seealso
-    tabularcolumns
-    todo
-    versionadded
-    versionchanged
+  codeauthor
+  confval
+  deprecated
+  event
+  highlight
+  hlist
+  index
+  literalinclude
+  nbgallery
+  only
+  rst:directive
+  sectionauthor
+  seealso
+  tabularcolumns
+  todo
+  versionadded
+  versionchanged
 enable-extensions =
-    # Look for strings that have {} in them but aren't f-strings.
-    # If there is a false positive from this in a file, put that in
-    # per-file-ignores.
-    FS003
+  # Look for strings that have {} in them but aren't f-strings.
+  # If there is a false positive from this in a file, put that in
+  # per-file-ignores.
+  FS003
 
 [coverage:run]
 omit =
@@ -199,19 +199,19 @@ omit =
 
 [coverage:report]
 exclude_lines =
-    coverage: ignore
-    ImportError
-    ModuleNotFoundError
-    @vectorize
-    @numba.vectorize
-    @numba.jit
-    @jit
-    @numba.njit
-    @njit
+  coverage: ignore
+  ImportError
+  ModuleNotFoundError
+  @vectorize
+  @numba.vectorize
+  @numba.jit
+  @jit
+  @numba.njit
+  @njit
 
 [codespell]
 skip = .tox,.git,.hypothesis,_build,__pycache__,*egg*,*.png,*.genx,*.geny
 # Occasionally codespell will have false positives. Put words here that
 # should be ignored when codespell checks spellings.
 ignore-words-list =
-   circularly
+  circularly

--- a/tox.ini
+++ b/tox.ini
@@ -94,7 +94,7 @@ deps =
   pygments
 commands =
   flake8 --bug-report
-  flake8 {toxinidir}{/}plasmapy --count --show-source --statistics
+  flake8 {toxinidir}{/}xrtpy --count --show-source --statistics
 
 [testenv:py38-minimal-pypi-import]
 basepython = python3.8

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ whitelist_externals=
 setenv =
     MPLBACKEND = agg
     COLUMNS = 180
-    PYTEST_COMMAND = pytest --pyargs xrtpy --durations=25 -n=auto --dist=loadfile
+    PYTEST_COMMAND = pytest --pyargs xrtpy
 extras = tests
 deps =
     astropydev: git+https://github.com/astropy/astropy
@@ -21,7 +21,6 @@ deps =
     cov: pytest-cov
     pytest-github-actions-annotate-failures
 commands =
-    !cov: {env:PYTEST_COMMAND} {posargs} -m 'not slow'
     all: {env:PYTEST_COMMAND} {posargs}
     cov-all: {env:PYTEST_COMMAND} {posargs} --cov=xrtpy --cov-report=xml --cov-config={toxinidir}{/}setup.cfg --cov-append --cov-report xml:coverage.xml
 
@@ -40,6 +39,9 @@ skip_install = true
 commands = coverage erase
 
 [testenv:build_docs]
+deps =
+  jinja2 < 3.1
+  docutils < 0.18
 changedir = {toxinidir}
 extras = docs
 setenv =
@@ -47,6 +49,9 @@ setenv =
 commands = sphinx-build docs docs{/}_build{/}html -W --keep-going -b html {posargs}
 
 [testenv:build_docs_no_examples]
+deps =
+  jinja2 < 3.1
+  docutils < 0.18
 changedir = {toxinidir}
 extras = docs
 setenv =
@@ -54,6 +59,9 @@ setenv =
 commands = sphinx-build -D nbsphinx_execute='never' docs docs{/}_build{/}html -b html {posargs}
 
 [testenv:build_docs_nitpicky]
+deps =
+  jinja2 < 3.1
+  docutils < 0.18
 changedir = {toxinidir}
 extras = docs
 setenv =

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,8 @@
 [tox]
 envlist = clean,py38,build_docs
 isolated_build = True
+indexserver =
+    NIGHTLY = https://pypi.anaconda.org/scipy-wheels-nightly/simple
 
 [testenv]
 whitelist_externals=
@@ -9,21 +11,25 @@ whitelist_externals=
 setenv =
     MPLBACKEND = agg
     COLUMNS = 180
-    PYTEST_COMMAND = pytest --pyargs xrtpy --durations=25 {toxinidir}{/}docs --ignore={toxinidir}{/}docs{/}conf.py
+    PYTEST_COMMAND = pytest --pyargs xrtpy --durations=25 -n=auto --dist=loadfile
 extras = tests
 deps =
-    numpydev: git+https://github.com/numpy/numpy
     astropydev: git+https://github.com/astropy/astropy
+    numpydev: git+https://github.com/numpy/numpy
+    sphinxdev: git+https://github.com/sphinx-doc/sphinx
     sunpydev: git+https://github.com/sunpy/sunpy
     cov: pytest-cov
     pytest-github-actions-annotate-failures
 commands =
-    cov: {env:PYTEST_COMMAND} {posargs} --cov=xrtpy --cov-report=xml --cov-config={toxinidir}{/}setup.cfg --cov-append --cov-report xml:coverage.xml
+    !cov: {env:PYTEST_COMMAND} {posargs} -m 'not slow'
+    all: {env:PYTEST_COMMAND} {posargs}
+    cov-all: {env:PYTEST_COMMAND} {posargs} --cov=xrtpy --cov-report=xml --cov-config={toxinidir}{/}setup.cfg --cov-append --cov-report xml:coverage.xml
 
 description =
     run tests
-    numpydev: with the git main version of numpy
     astropydev: with the git main version of astropy
+    numpydev: with the git main version of numpy
+    sphinxdev: with the development version of sphinx
     sunpydev: with the git main version of sunpy
     minimal: with minimal versions of dependencies
     cov: with code coverage
@@ -36,15 +42,26 @@ commands = coverage erase
 [testenv:build_docs]
 changedir = {toxinidir}
 extras = docs
-deps =
-  jinja2 < 3.1
-  docutils < 0.18
 setenv =
     HOME = {envtmpdir}
-commands = sphinx-build docs docs{/}_build{/}html -W -b html
+commands = sphinx-build docs docs{/}_build{/}html -W --keep-going -b html {posargs}
+
+[testenv:build_docs_no_examples]
+changedir = {toxinidir}
+extras = docs
+setenv =
+    HOME = {envtmpdir}
+commands = sphinx-build -D nbsphinx_execute='never' docs docs{/}_build{/}html -b html {posargs}
+
+[testenv:build_docs_nitpicky]
+changedir = {toxinidir}
+extras = docs
+setenv =
+    HOME = {envtmpdir}
+commands = sphinx-build docs docs{/}_build{/}html -W -n --keep-going -b html {posargs}
 
 # This env tests minimal versions of each dependency.
-[testenv:py38-minimal]
+[testenv:py38-all-minimal]
 basepython = python3.8
 extras =
 deps =
@@ -60,16 +77,25 @@ setenv =
 
 [testenv:linters]
 deps =
-    flake8
-    pydocstyle
-    flake8-rst-docstrings
-    pygments
+  dlint
+  flake8
+  flake8-absolute-import
+  flake8-rst-docstrings
+  flake8-use-fstring
+  pydocstyle
+  pygments
 commands =
-    flake8 --bug-report
-    flake8 {toxinidir}{/}xrtpy --count --show-source --statistics
+  flake8 --bug-report
+  flake8 {toxinidir}{/}plasmapy --count --show-source --statistics
 
 [testenv:py38-minimal-pypi-import]
 basepython = python3.8
 extras =
 deps =
 commands = python -c 'import xrtpy'
+
+[testenv:codespell]
+deps =
+  codespell
+commands =
+  codespell .


### PR DESCRIPTION
This pull request adopts the configuration for requirements that is being used in PlasmaPy.  The requirements are split into different files in the `requirements` directory.  For example, `requirements/install.txt` has the requirements for installation, `tests.txt` for tests, and so on.  The top-level `requirements.txt` file doesn't list requirements directly, but rather uses the requirements that are defined in these other files.  The requirements also need to be defined in the `setup.cfg` and `pyproject.toml` project configuration files, so I added them there too.