### PR TITLE
Updated CCD gain right port value.

### DIFF
--- a/xrtpy/response/channel.py
+++ b/xrtpy/response/channel.py
@@ -298,13 +298,13 @@ class CCD:
 
     @property
     @u.quantity_input
-    def ccd_gain_left(self) -> u.electron / u.DN:
+    def ccd_gain_left(self) -> (u.electron / u.DN):
         """Gain when reading the left port of the CCD."""
         return u.Quantity(self._ccd_data["GAIN_L"], (u.electron / u.DN))
 
     @property
     @u.quantity_input
-    def ccd_gain_right(self) -> u.electron / u.DN:
+    def ccd_gain_right(self) -> (u.electron / u.DN):
         """Gain when reading the right port of the CCD."""
         return u.Quantity(57.5, (u.electron / u.DN))
 

--- a/xrtpy/response/channel.py
+++ b/xrtpy/response/channel.py
@@ -300,7 +300,7 @@ class CCD:
     @u.quantity_input
     def ccd_gain_left(self) -> u.electron / u.DN:
         """Gain when reading the left port of the CCD."""
-        return u.Quantity(self._ccd_data["GAIN_L"], (u.electron / u.DN))
+        return u.Quantity(self._ccd_data["GAIN_L"], u.electron / u.DN)
 
     @property
     @u.quantity_input

--- a/xrtpy/response/channel.py
+++ b/xrtpy/response/channel.py
@@ -304,7 +304,7 @@ class CCD:
 
     @property
     @u.quantity_input
-    def ccd_gain_right(self) -> (u.electron / u.DN):
+    def ccd_gain_right(self) -> u.electron / u.DN:
         """Gain when reading the right port of the CCD."""
         return u.Quantity(57.5, (u.electron / u.DN))
 

--- a/xrtpy/response/channel.py
+++ b/xrtpy/response/channel.py
@@ -306,7 +306,7 @@ class CCD:
     @u.quantity_input
     def ccd_gain_right(self) -> u.electron:
         """Gain when reading the right port of the CCD."""
-        return u.Quantity(self._ccd_data["GAIN_R"], u.electron)
+        return u.Quantity(57.5, u.electron)
 
     @property
     def ccd_name(self) -> str:

--- a/xrtpy/response/channel.py
+++ b/xrtpy/response/channel.py
@@ -306,7 +306,7 @@ class CCD:
     @u.quantity_input
     def ccd_gain_right(self) -> u.electron / u.DN:
         """Gain when reading the right port of the CCD."""
-        return u.Quantity(57.5, (u.electron / u.DN))
+        return u.Quantity(57.5, u.electron / u.DN)
 
     @property
     def ccd_name(self) -> str:

--- a/xrtpy/response/channel.py
+++ b/xrtpy/response/channel.py
@@ -298,7 +298,7 @@ class CCD:
 
     @property
     @u.quantity_input
-    def ccd_gain_left(self) -> (u.electron / u.DN):
+    def ccd_gain_left(self) -> u.electron / u.DN:
         """Gain when reading the left port of the CCD."""
         return u.Quantity(self._ccd_data["GAIN_L"], (u.electron / u.DN))
 

--- a/xrtpy/response/channel.py
+++ b/xrtpy/response/channel.py
@@ -298,15 +298,15 @@ class CCD:
 
     @property
     @u.quantity_input
-    def ccd_gain_left(self) -> u.electron:
+    def ccd_gain_left(self) -> u.electron / u.DN:
         """Gain when reading the left port of the CCD."""
-        return u.Quantity(self._ccd_data["GAIN_L"], u.electron)
+        return u.Quantity(self._ccd_data["GAIN_L"], (u.electron / u.DN))
 
     @property
     @u.quantity_input
-    def ccd_gain_right(self) -> u.electron:
+    def ccd_gain_right(self) -> u.electron / u.DN:
         """Gain when reading the right port of the CCD."""
-        return u.Quantity(57.5, u.electron)
+        return u.Quantity(57.5, (u.electron / u.DN))
 
     @property
     def ccd_name(self) -> str:

--- a/xrtpy/response/temperature_response.py
+++ b/xrtpy/response/temperature_response.py
@@ -173,7 +173,7 @@ class TemperatureResponseFundamental:
 
     @property
     @u.quantity_input
-    def ccd_gain_right(self):
+    def ccd_gain_right(self) -> u.electron / u.DN:
         """Provide the camera gain in electrons per data number."""
         return Channel(self.name).ccd.ccd_gain_right
 

--- a/xrtpy/response/temperature_response.py
+++ b/xrtpy/response/temperature_response.py
@@ -173,9 +173,9 @@ class TemperatureResponseFundamental:
 
     @property
     @u.quantity_input
-    def ccd_gain_right(self) -> 1 / u.DN:
+    def ccd_gain_right(self):
         """Provide the camera gain in electrons per data number."""
-        return Channel(self.name).ccd.ccd_gain_right / u.DN
+        return Channel(self.name).ccd.ccd_gain_right
 
     @u.quantity_input
     def temperature_response(self) -> u.DN * u.cm**5 / (u.s * u.pix):

--- a/xrtpy/response/tests/test_channel.py
+++ b/xrtpy/response/tests/test_channel.py
@@ -782,9 +782,10 @@ def test_ccd_gain_right(channel_name):
     idl_ccd_gain_right_auto = (
         v6_genx_s[_channel_name_to_index_mapping[channel_name]]["CCD"]["GAIN_R"]
         * u.electron
+        / u.DN
     )
 
-    idl_ccd_gain_right_correction = 57.5 * u.electron
+    idl_ccd_gain_right_correction = 57.5 * u.electron * u.DN
 
     assert u.isclose(ccd_gain_right, idl_ccd_gain_right_correction)
 

--- a/xrtpy/response/tests/test_channel.py
+++ b/xrtpy/response/tests/test_channel.py
@@ -765,10 +765,9 @@ def test_ccd_gain_left(channel_name):
     channel_filter = Channel(channel_name)
     ccd_gain_left = channel_filter.ccd.ccd_gain_left
 
-    idl_ccd_gain_left_auto = (
-        v6_genx_s[_channel_name_to_index_mapping[channel_name]]["CCD"]["GAIN_L"]
-        * u.electron
-    )
+    idl_ccd_gain_left_auto = v6_genx_s[_channel_name_to_index_mapping[channel_name]][
+        "CCD"
+    ]["GAIN_L"] * (u.electron / u.DN)
 
     assert u.isclose(ccd_gain_left, idl_ccd_gain_left_auto)
 
@@ -779,13 +778,11 @@ def test_ccd_gain_right(channel_name):
     channel_filter = Channel(channel_name)
     ccd_gain_right = channel_filter.ccd.ccd_gain_right
 
-    idl_ccd_gain_right_auto = (
-        v6_genx_s[_channel_name_to_index_mapping[channel_name]]["CCD"]["GAIN_R"]
-        * u.electron
-        / u.DN
-    )
+    idl_ccd_gain_right_auto = v6_genx_s[_channel_name_to_index_mapping[channel_name]][
+        "CCD"
+    ]["GAIN_R"] * (u.electron / u.DN)
 
-    idl_ccd_gain_right_correction = 57.5 * u.electron * u.DN
+    idl_ccd_gain_right_correction = 57.5 * (u.electron / u.DN)
 
     assert u.isclose(ccd_gain_right, idl_ccd_gain_right_correction)
 

--- a/xrtpy/response/tests/test_channel.py
+++ b/xrtpy/response/tests/test_channel.py
@@ -784,7 +784,9 @@ def test_ccd_gain_right(channel_name):
         * u.electron
     )
 
-    assert u.isclose(ccd_gain_right, idl_ccd_gain_right_auto)
+    idl_ccd_gain_right_correction = 57.5 * u.electron
+
+    assert u.isclose(ccd_gain_right, idl_ccd_gain_right_correction)
 
 
 @pytest.mark.parametrize("channel_name", channel_names)


### PR DESCRIPTION
Updating CCD gain port right value to 57.5 e-.  Genx file used to create Channel (genx file)  has hard code value of 59.09 e- for CCD right gain. Explained by @kreevescfa, 57.5 e- is the true value to the right port gain, reference the camera paper (https://ui.adsabs.harvard.edu/abs/2008SoPh..249..263K/abstract). GR [e−/DN] = 59.1 + 0.026 T [◦C]. The camera is ran at -60C, so from this formula, the gain is 57.5 -e/DN.