### PR TITLE
Update pre-commit and codespell

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -74,7 +74,8 @@ repos:
   rev: v2.2.2
   hooks:
   - id: codespell
-    args: [--config pyproject.toml]
+    additional_dependencies:
+    - tomli
 
 - repo: https://github.com/asottile/pyupgrade
   rev: v2.38.2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,7 @@ repos:
   - id: check-ast
   - id: trailing-whitespace
   - id: end-of-file-fixer
+    exclude: .*\.fits
   - id: check-merge-conflict
     exclude: .*\.rst
   - id: requirements-txt-fixer

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,9 @@ build-backend = "setuptools.build_meta"
 [tool.codespell]
 skip = "*.genx,*.geny,*.png,*egg*,.git,.hypothesis,.nox,.tox,.idea,__pycache__,_build"
 ignore-words-list = """
-circularly"""
+circularly,
+te
+"""
 
 [tool.gilesbot]
 


### PR DESCRIPTION
There were a couple of issues related to pre-commit and codespell that came up in #89.  This PR:

 - Apply a fix to the pre-commit hook for codespell so that the configuration from `pyproject.toml` can be read in
 - Add `te` to list of ignore words in codespell
 - Have end-of-file-fixer ignore `.fits` files (and maybe some others)