### PR TITLE
Fix time handling in contamination calculations

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -86,6 +86,8 @@ developer =
 
 [options.package_data]
 xrtpy = data/*
+xrtpy.response = data/*.txt, data/*.geny
+xrtpy.response.tests = data/*/*/*.txt
 
 [tool:pytest]
 minversion = 5.4

--- a/xrtpy/response/channel.py
+++ b/xrtpy/response/channel.py
@@ -11,7 +11,6 @@ __all__ = [
 ]
 
 import numpy as np
-import scipy.io
 import sunpy.io.special
 import sunpy.time
 

--- a/xrtpy/response/effective_area.py
+++ b/xrtpy/response/effective_area.py
@@ -3,7 +3,7 @@ __all__ = [
     "effective_area",
 ]
 
-import datetime
+import astropy.time
 import math
 import numpy as np
 import os
@@ -13,7 +13,6 @@ import sunpy.time
 
 from astropy import units as u
 from astropy.utils.data import get_pkg_data_filename
-from datetime import timedelta
 from functools import cached_property
 from pathlib import Path
 from scipy import interpolate
@@ -51,11 +50,15 @@ _ccd_contam_file = scipy.io.readsav(_ccd_contam_filename)
 _filter_contam_file = scipy.io.readsav(_filter_contam_filename)
 
 # CCD contam geny files keys for time and date.
-_ccd_contamination_file_time = _ccd_contam_file["p1"]
+_ccd_contamination_file_time = astropy.time.Time(
+    _ccd_contam_file["p1"], format="utime", scale="utc"
+)
 _ccd_contamination = _ccd_contam_file["p2"]
 
 # Filter contam geny files keys for time and date.
-_filter_contamination_file_time = _filter_contam_file["p1"]
+_filter_contamination_file_time = astropy.time.Time(
+    _filter_contam_file["p1"], format="utime", scale="utc"
+)
 _filter_contamination = _filter_contam_file["p2"]
 
 
@@ -91,100 +94,30 @@ class EffectiveAreaFundamental:
     @observation_date.setter
     def observation_date(self, date):
         """Validating users requested observation date."""
-        astropy_time = sunpy.time.parse_time(date)  # Astropy time in utc
-        observation_date = astropy_time.datetime
+        observation_date = sunpy.time.parse_time(date)
 
         if observation_date <= epoch:
             raise ValueError(
-                f"Invalid date: {observation_date}.\n Date must be after September 22nd, 2006 21:36:00."
+                f"Invalid date: {observation_date.iso}.\n Date must be after {epoch.iso}."
             )
         self._observation_date = observation_date
 
     @property
     def xrt_contam_on_ccd_geny_update(self):
-        """Return a string of the last time the file was modified."""
+        """Return the time the file was last modified."""
         modified_time = os.path.getmtime(_ccd_contam_filename)
-        modified_time_dt = datetime.datetime.fromtimestamp(modified_time)
+        modified_time = astropy.time.Time(modified_time, format="unix")
 
-        return modified_time_dt.strftime("%Y/%m/%d")
-
-    @property
-    def ccd_data_dates_to_seconds(self):
-        """Converting CCD data dates to datetimes."""
-
-        ccd_data_dates_dt = []
-        ccd_data_dates_to_seconds = []
-        for time in _ccd_contamination_file_time:
-            t0 = _ccd_contamination_file_time[0]
-            dt = time - t0
-            ccd_data_dates_dt.append(epoch + timedelta(0, dt))
-            ccd_data_dates_to_seconds.append(
-                float((epoch + timedelta(0, dt)).strftime("%S"))
-            )
-
-        if self.observation_date > ccd_data_dates_dt[-1]:
-            raise ValueError(
-                "No contamination data is presently available for "
-                f"{self.observation_date}.\n The latest available data is on "
-                f"{ccd_data_dates_dt[-1]}.\n Contamination data is "
-                "updated periodically. The last update was on "
-                f"{self.xrt_contam_on_ccd_geny_update}. If this is more "
-                "than one month ago, please raise an issue at: "
-                "https://github.com/HinodeXRT/xrtpy/issues/new"
-            )
-        return ccd_data_dates_to_seconds
-
-    @property
-    def ccd_observation_date_to_seconds(self):
-        """Converting users observation date into seconds with
-        respect to CCD contamination data. Used for interpolation."""
-
-        ccd_observation_date_to_seconds = []
-        for time in _ccd_contamination_file_time:
-            t0 = _ccd_contamination_file_time[0]
-            dt = time - t0
-            ccd_observation_date_to_seconds.append(
-                (self.observation_date + timedelta(0, dt)).strftime("%S")
-            )
-
-        return ccd_observation_date_to_seconds[0]
-
-    @property
-    def filter_observation_date_to_seconds(self):
-        """Converting users observation date into seconds with respect to filter contamination data. Used for interpolation."""
-
-        filter_observation_date_to_seconds = []
-        for time in _filter_contamination_file_time:
-            t0 = _filter_contamination_file_time[0]
-            dt = time - t0
-            filter_observation_date_to_seconds.append(
-                (self.observation_date + timedelta(0, dt)).strftime("%S")
-            )
-
-        return filter_observation_date_to_seconds[0]
-
-    @property
-    def filter_data_dates_to_seconds(self):
-        """Converting filter contamination data dates to datetimes."""
-
-        filter_data_dates_to_seconds = []
-        for time in _filter_contamination_file_time:
-            t0 = _filter_contamination_file_time[0]
-            dt = time - t0
-            filter_data_dates_to_seconds.append(
-                float((epoch + timedelta(0, dt)).strftime("%S"))
-            )
-
-        return filter_data_dates_to_seconds
+        return modified_time
 
     @property
     def contamination_on_CCD(self):
         """Calculation of contamination layer on the CCD, thickness given in Angstrom (Å)."""
 
         interpolater = scipy.interpolate.interp1d(
-            self.ccd_data_dates_to_seconds, _ccd_contamination, kind="linear"
+            _ccd_contamination_file_time.utime, _ccd_contamination, kind="linear"
         )
-        return interpolater(self.ccd_observation_date_to_seconds)
+        return interpolater(self.observation_date.utime)
 
     @property
     def filter_index_mapping_to_name(self):
@@ -212,9 +145,9 @@ class EffectiveAreaFundamental:
         Thickness of the contamination layer on a filter."""
 
         interpolater = scipy.interpolate.interp1d(
-            self.filter_data_dates_to_seconds, self.filter_data, kind="linear"
+            _filter_contamination_file_time.utime, self.filter_data, kind="linear"
         )
-        return interpolater(self.filter_observation_date_to_seconds)
+        return interpolater(self.observation_date.utime)
 
     @cached_property
     def n_DEHP_attributes(self):

--- a/xrtpy/response/effective_area.py
+++ b/xrtpy/response/effective_area.py
@@ -219,8 +219,9 @@ class EffectiveAreaFundamental:
     @cached_property
     def n_DEHP_attributes(self):
         """Diethylhexylphthalate: Wavelength (nm), Delta, Beta."""
-        _n_DEHP_filename = get_pkg_data_filename("data/n_DEHP.txt",
-                                                 package="xrtpy.response.data")
+        _n_DEHP_filename = get_pkg_data_filename(
+            "data/n_DEHP.txt", package="xrtpy.response.data"
+        )
 
         with open(_n_DEHP_filename) as n_DEHP:
             list_of_DEHP_attributes = []

--- a/xrtpy/response/effective_area.py
+++ b/xrtpy/response/effective_area.py
@@ -220,7 +220,7 @@ class EffectiveAreaFundamental:
     def n_DEHP_attributes(self):
         """Diethylhexylphthalate: Wavelength (nm), Delta, Beta."""
         _n_DEHP_filename = get_pkg_data_filename(
-            "data/n_DEHP.txt", package="xrtpy.response.data"
+            "data/n_DEHP.txt", package="xrtpy.response"
         )
 
         with open(_n_DEHP_filename) as n_DEHP:

--- a/xrtpy/response/effective_area.py
+++ b/xrtpy/response/effective_area.py
@@ -12,6 +12,7 @@ import sunpy.io.special
 import sunpy.time
 
 from astropy import units as u
+from astropy.utils.data import get_pkg_data_filename
 from datetime import timedelta
 from functools import cached_property
 from pathlib import Path
@@ -218,7 +219,8 @@ class EffectiveAreaFundamental:
     @cached_property
     def n_DEHP_attributes(self):
         """Diethylhexylphthalate: Wavelength (nm), Delta, Beta."""
-        _n_DEHP_filename = Path(__file__).parent.absolute() / "data" / "n_DEHP.txt"
+        _n_DEHP_filename = get_pkg_data_filename("data/n_DEHP.txt",
+                                                 package="xrtpy.response.data")
 
         with open(_n_DEHP_filename) as n_DEHP:
             list_of_DEHP_attributes = []

--- a/xrtpy/response/temperature_response.py
+++ b/xrtpy/response/temperature_response.py
@@ -8,9 +8,8 @@ import sunpy.time
 
 from astropy import units as u
 from astropy.constants import c, h
-from datetime import datetime
 from pathlib import Path
-from scipy import integrate, interpolate
+from scipy import interpolate
 
 from xrtpy.response.channel import Channel, resolve_filter_name
 from xrtpy.response.effective_area import effective_area

--- a/xrtpy/response/temperature_response.py
+++ b/xrtpy/response/temperature_response.py
@@ -4,7 +4,6 @@ __all__ = [
 
 import numpy as np
 import scipy.io
-import sunpy.time
 
 from astropy import units as u
 from astropy.constants import c, h
@@ -12,8 +11,7 @@ from pathlib import Path
 from scipy import interpolate
 
 from xrtpy.response.channel import Channel, resolve_filter_name
-from xrtpy.response.effective_area import effective_area
-from xrtpy.util.time import epoch
+from xrtpy.response.effective_area import EffectiveAreaFundamental
 
 _c_Å_per_s = c.to(u.angstrom / u.second).value
 _h_eV_s = h.to(u.eV * u.s).value
@@ -47,7 +45,9 @@ class TemperatureResponseFundamental:
 
     def __init__(self, filter_name, observation_date):
         self._name = resolve_filter_name(filter_name)
-        self.observation_date = observation_date
+        self._effective_area_fundamental = EffectiveAreaFundamental(
+            self.name, observation_date
+        )
         self._channel = Channel(self.name)
 
     @property
@@ -57,19 +57,8 @@ class TemperatureResponseFundamental:
 
     @property
     def observation_date(self):
-        """Users date of observation."""
-        return self._observation_date
-
-    @observation_date.setter
-    def observation_date(self, date):
-        """Validating users requested observation date."""
-        astropy_time = sunpy.time.parse_time(date)  # Astropy time in utc
-        observation_date = astropy_time.datetime
-        if observation_date <= epoch:
-            raise ValueError(
-                rf"Invalid date: {observation_date}.\n Date must be after September 22nd, 2006 21:36:00."
-            )
-        self._observation_date = observation_date
+        """Date of the observation"""
+        return self._effective_area_fundamental.observation_date
 
     @property
     def CHIANTI_version(self):
@@ -152,7 +141,7 @@ class TemperatureResponseFundamental:
 
     @u.quantity_input
     def effective_area(self) -> u.cm**2:
-        return effective_area(self.name, self.observation_date)
+        return self._effective_area_fundamental.effective_area()
 
     @u.quantity_input
     def integration(self) -> u.electron * u.cm**5 / (u.s * u.pix):

--- a/xrtpy/response/tests/test_effective_area.py
+++ b/xrtpy/response/tests/test_effective_area.py
@@ -101,9 +101,16 @@ def test_EffectiveArea_exception_is_raised(name, date):
 
 def get_IDL_data_files():
     files = []
-    data_root = 'data/effective_area_IDL_testing_files/'
-    for top_dir in get_pkg_data_filenames(data_root, package='xrtpy.response.tests', ):
-        files += list(get_pkg_data_filenames(top_dir, package='xrtpy.response.tests', pattern='*.txt'))
+    data_root = "data/effective_area_IDL_testing_files/"
+    for top_dir in get_pkg_data_filenames(
+        data_root,
+        package="xrtpy.response.tests",
+    ):
+        files += list(
+            get_pkg_data_filenames(
+                top_dir, package="xrtpy.response.tests", pattern="*.txt"
+            )
+        )
     return sorted(files)
 
 

--- a/xrtpy/response/tests/test_effective_area.py
+++ b/xrtpy/response/tests/test_effective_area.py
@@ -2,6 +2,7 @@ import glob
 import pytest
 
 from astropy import units as u
+from astropy.utils.data import get_pkg_data_filenames
 from datetime import datetime
 from pathlib import Path
 
@@ -99,13 +100,11 @@ def test_EffectiveArea_exception_is_raised(name, date):
 
 
 def get_IDL_data_files():
-    directory = (
-        Path(__file__).parent.parent.absolute()
-        / "data"
-        / "effective_area_IDL_testing_files"
-    )
-    filter_data_files = directory.glob("**/*.txt")
-    return sorted(filter_data_files)
+    files = []
+    data_root = 'data/effective_area_IDL_testing_files/'
+    for top_dir in get_pkg_data_filenames(data_root, package='xrtpy.response.tests', ):
+        files += list(get_pkg_data_filenames(top_dir, package='xrtpy.response.tests', pattern='*.txt'))
+    return sorted(files)
 
 
 filenames = get_IDL_data_files()

--- a/xrtpy/response/tests/test_temperature_response.py
+++ b/xrtpy/response/tests/test_temperature_response.py
@@ -10,9 +10,16 @@ from xrtpy.response.temperature_response import TemperatureResponseFundamental
 
 def get_IDL_data_files():
     files = []
-    data_root = 'data/temperature_response_IDL_testing_files/'
-    for top_dir in get_pkg_data_filenames(data_root, package='xrtpy.response.tests', ):
-        files += list(get_pkg_data_filenames(top_dir, package='xrtpy.response.tests', pattern='*.txt'))
+    data_root = "data/temperature_response_IDL_testing_files/"
+    for top_dir in get_pkg_data_filenames(
+        data_root,
+        package="xrtpy.response.tests",
+    ):
+        files += list(
+            get_pkg_data_filenames(
+                top_dir, package="xrtpy.response.tests", pattern="*.txt"
+            )
+        )
     return sorted(files)
 
 

--- a/xrtpy/response/tests/test_temperature_response.py
+++ b/xrtpy/response/tests/test_temperature_response.py
@@ -1,6 +1,7 @@
-import glob
+import astropy.units as u
 import pytest
 
+from astropy.utils.data import get_pkg_data_filenames
 from datetime import datetime
 from pathlib import Path
 
@@ -8,13 +9,11 @@ from xrtpy.response.temperature_response import TemperatureResponseFundamental
 
 
 def get_IDL_data_files():
-    path = (
-        Path(__file__).parent.parent.absolute()
-        / "data"
-        / "temperature_response_IDL_testing_files"
-    )
-    filter_data_files = list(path.glob("**/*.*"))
-    return sorted(filter_data_files)
+    files = []
+    data_root = 'data/temperature_response_IDL_testing_files/'
+    for top_dir in get_pkg_data_filenames(data_root, package='xrtpy.response.tests', ):
+        files += list(get_pkg_data_filenames(top_dir, package='xrtpy.response.tests', pattern='*.txt'))
+    return sorted(files)
 
 
 filenames = get_IDL_data_files()
@@ -70,8 +69,7 @@ def _IDL_temperature_response_raw_data(filename):
 
 
 @pytest.mark.parametrize("filename", filenames)
-def test_temperature_response(filename, allclose):
-
+def test_temperature_response(filename):
     IDL_data = _IDL_raw_data_list(filename)
 
     filter_name = IDL_test_filter_name(IDL_data)
@@ -82,6 +80,6 @@ def test_temperature_response(filename, allclose):
     instance = TemperatureResponseFundamental(filter_name, filter_obs_date)
     actual_temperature_response = instance.temperature_response()
 
-    assert allclose(
+    assert u.allclose(
         actual_temperature_response.value, IDL_temperature_response, rtol=1e-6
     )

--- a/xrtpy/util/time.py
+++ b/xrtpy/util/time.py
@@ -1,3 +1,5 @@
+import astropy.time
+
 __all__ = [
     "epoch",
 ]
@@ -5,7 +7,7 @@ __all__ = [
 from datetime import datetime, timedelta
 
 # Hinode-XRT mission elapsed time "Epoch" is Sept 22, 2006 21:36:00.
-epoch = datetime(year=2006, month=9, day=22, hour=21, minute=36, second=0)
+epoch = astropy.time.Time("2006-09-22 21:36:00")
 
 
 def xrt_data_time_to_dt(data_time, epoch):


### PR DESCRIPTION
Fixes #98
Fixes #97
Fixes #78 

I've expanded this PR a bit to achieve two things:

- Unskip a temperature response tests that were previously not being run
- Fix issue of NaNs resulting from interpolation of filter and CCD contamination.

I am happy to separate this out into multiple PRs if needed as this now expands the scope of my original PR. However, I think it makes sense to keep this all in one as I think this was one of the issues causing the effective area tests to fail.

Re: the second point, I resolved this issue by dropping the use of `datetime` everywhere and using `astropy.time` to handle all times. I've removed a lot of time conversion code as it turns out that `astropy.time`, via a time format defined in `sunpy`, supports the time format in the filter and CCD contamination files so there is no need to subtract times or add seconds to epochs manually. See [the docs on the "utime" format](https://docs.sunpy.org/en/stable/generated/api/sunpy.time.TimeUTime.html#sunpy.time.TimeUTime) for more information. This is equivalent to the IDL approach of passing everything through the `anytim` function. Furthermore, because this time format is just number of seconds since 1979-01-01, the interpolation can all be done in just this time system.

Additionally, I'll point out that all of the temperature response tests fail. Given that they have apparently not been run prior to this PR, it is not clear whether changes I've introduced here are causing that failure or not. I've not yet looked into how different the results are when compared with the IDL temperature responses.