### PR TITLE
Update reStructuredText substitutions

### DIFF
--- a/docs/_substitutions.rst
+++ b/docs/_substitutions.rst
@@ -1,6 +1,7 @@
 .. |bibliography| replace:: :ref:`bibliography`\
 .. |glossary| replace:: :ref:`glossary`\
 .. |inf| replace:: `~numpy.inf`
+.. |Map| replace:: `sunpy.map.Map`
 .. |minpython| replace:: 3.8
 .. |nan| replace:: `~numpy.nan`
 .. |ndarray| replace:: :class:`~numpy.ndarray`
@@ -21,23 +22,20 @@
    nitpick_ignore_regex in docs/conf.py so that it doesn't get counted
    as an error in a nitpicky doc build (e.g., tox -e doc_build_nitpicky).
 
-.. _`docs/_static`: https://github.com/PlasmaPy/PlasmaPy/tree/main/docs/_static
+.. _`docs/_static`: https://github.com/HinodeXRT/xrtpy/tree/main/docs/_static
 .. |docs/_static| replace:: :file:`docs/_static`
 
-.. _`docs/_static/css`: https://github.com/PlasmaPy/PlasmaPy/tree/main/docs/_static/css
-.. |docs/_static/css| replace:: :file:`docs/_static/css`
-
-.. _`docs/api_static`: https://github.com/PlasmaPy/PlasmaPy/tree/main/docs/api_static
+.. _`docs/api_static`: https://github.com/HinodeXRT/xrtpy/tree/main/docs/api_static
 .. |docs/api_static| replace:: :file:`docs/api_static`
 
-.. _`docs/conf.py`: https://github.com/PlasmaPy/PlasmaPy/blob/main/docs/conf.py
+.. _`docs/conf.py`: https://github.com/HinodeXRT/xrtpy/blob/main/docs/conf.py
 .. |docs/conf.py| replace:: :file:`docs/conf.py`
 
-.. _`docs/glossary.rst`: https://github.com/PlasmaPy/PlasmaPy/blob/main/docs/glossary.rst
+.. _`docs/glossary.rst`: https://github.com/HinodeXRT/PlasmaPy/blob/main/docs/glossary.rst
 .. |docs/glossary.rst| replace:: :file:`docs/glossary.rst`
 
-.. _`docs/bibliography.bib`: https://github.com/PlasmaPy/PlasmaPy/blob/main/docs/bibliography.bib
+.. _`docs/bibliography.bib`: https://github.com/HinodeXRT/xrtpy/blob/main/docs/bibliography.bib
 .. |docs/bibliography.bib| replace:: :file:`docs/bibliography.bib`
 
-.. _`setup.cfg`: https://github.com/PlasmaPy/PlasmaPy/blob/main/setup.cfg
+.. _`setup.cfg`: https://github.com/HinodeXRT/xrtpy/blob/main/setup.cfg
 .. |setup.cfg| replace:: :file:`setup.cfg`

--- a/docs/_substitutions.rst
+++ b/docs/_substitutions.rst
@@ -23,9 +23,6 @@
    nitpick_ignore_regex in docs/conf.py so that it doesn't get counted
    as an error in a nitpicky doc build (e.g., tox -e doc_build_nitpicky).
 
-.. _`docs/_static`: https://github.com/HinodeXRT/xrtpy/tree/main/docs/_static
-.. |docs/_static| replace:: :file:`docs/_static`
-
 .. _`docs/api_static`: https://github.com/HinodeXRT/xrtpy/tree/main/docs/api_static
 .. |docs/api_static| replace:: :file:`docs/api_static`
 
@@ -37,6 +34,3 @@
 
 .. _`docs/bibliography.bib`: https://github.com/HinodeXRT/xrtpy/blob/main/docs/bibliography.bib
 .. |docs/bibliography.bib| replace:: :file:`docs/bibliography.bib`
-
-.. _`setup.cfg`: https://github.com/HinodeXRT/xrtpy/blob/main/setup.cfg
-.. |setup.cfg| replace:: :file:`setup.cfg`

--- a/docs/_substitutions.rst
+++ b/docs/_substitutions.rst
@@ -8,6 +8,7 @@
 .. |Quantity| replace:: :class:`~astropy.units.Quantity`
 .. |TimeDelta| replace:: :class:`~astropy.time.TimeDelta`
 .. |Time| replace:: :class:`~astropy.time.Time`
+.. |XRTMap| replace:: `~sunpy.map.sources.hinode.XRTMap`
 .. |Channel| replace:: :class:`~xrtpy.response.channel.Channel`
 .. |EffectiveAreaFundamental| replace:: :class:`~xrtpy.response.effective_area.EffectiveAreaFundamental`
 .. |TemperatureResponseFundamental| replace:: :class:`~xrtpy.response.temperature_response.TemperatureResponseFundamental`

--- a/docs/_substitutions.rst
+++ b/docs/_substitutions.rst
@@ -1,4 +1,6 @@
 .. |bibliography| replace:: :ref:`bibliography`\
+.. |Channel| replace:: :class:`~xrtpy.response.channel.Channel`
+.. |EffectiveAreaFundamental| replace:: :class:`~xrtpy.response.effective_area.EffectiveAreaFundamental`
 .. |glossary| replace:: :ref:`glossary`\
 .. |inf| replace:: `~numpy.inf`
 .. |Map| replace:: `sunpy.map.Map`
@@ -6,12 +8,10 @@
 .. |nan| replace:: `~numpy.nan`
 .. |ndarray| replace:: :class:`~numpy.ndarray`
 .. |Quantity| replace:: :class:`~astropy.units.Quantity`
+.. |TemperatureResponseFundamental| replace:: :class:`~xrtpy.response.temperature_response.TemperatureResponseFundamental`
 .. |TimeDelta| replace:: :class:`~astropy.time.TimeDelta`
 .. |Time| replace:: :class:`~astropy.time.Time`
 .. |XRTMap| replace:: `~sunpy.map.sources.hinode.XRTMap`
-.. |Channel| replace:: :class:`~xrtpy.response.channel.Channel`
-.. |EffectiveAreaFundamental| replace:: :class:`~xrtpy.response.effective_area.EffectiveAreaFundamental`
-.. |TemperatureResponseFundamental| replace:: :class:`~xrtpy.response.temperature_response.TemperatureResponseFundamental`
 
 .. A workaround for nested inline literals so that the filename will get
    formatted like a file but will be a link. In the text, these get used


### PR DESCRIPTION
Following up on a suggestion for #89, this PR updates some reST substitutions, including for `|Map|`.  There are also some substitutions which still used `PlasmaPy/PlasmaPy`.