### PR TITLE
Add upper limit to version of sphinx-gallery

### DIFF
--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -15,7 +15,7 @@ pygments >= 2.11.0
 sphinx >= 4.5.0
 sphinx-changelog
 sphinx-copybutton
-sphinx-gallery
+sphinx-gallery < 0.11.0
 sphinx-hoverxref
 sphinx_automodapi
 sphinx_rtd_theme >= 1.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -72,7 +72,7 @@ docs =
     sphinx_automodapi
     sphinx-changelog
     sphinx-copybutton
-    sphinx-gallery
+    sphinx-gallery < 0.11.0
     sphinx-hoverxref
     sphinx_rtd_theme >= 1.0.0
     sphinxcontrib-bibtex


### PR DESCRIPTION
This is to fix an issue with the formatting of the example notebook galleries.  See https://github.com/PlasmaPy/PlasmaPy/pull/1654 for details.