### PR TITLE
Build changelog for 0.2.0 release

### DIFF
--- a/changelog/102.doc.rst
+++ b/changelog/102.doc.rst
@@ -1,1 +1,0 @@
-Updated effective area example notebook.

--- a/changelog/104.removal.rst
+++ b/changelog/104.removal.rst
@@ -1,1 +1,0 @@
-Fixed time handling in contamination calculations using `astropy.time`.

--- a/changelog/111.bugfix.rst
+++ b/changelog/111.bugfix.rst
@@ -1,1 +1,0 @@
-Addressed and fixed the temperature response 'NAN' calculations output.

--- a/changelog/128.doc.rst
+++ b/changelog/128.doc.rst
@@ -1,1 +1,0 @@
-Added a changelog.

--- a/changelog/89.feature.rst
+++ b/changelog/89.feature.rst
@@ -1,1 +1,0 @@
-Derived temperature and emission measure for a pair of images, `xrtpy.response.xrt_teem.xrt_teem`.

--- a/changelog/94.doc.rst
+++ b/changelog/94.doc.rst
@@ -1,1 +1,0 @@
-Updated temperature response example notebook.

--- a/docs/changelog/0.2.0.rst
+++ b/docs/changelog/0.2.0.rst
@@ -4,23 +4,20 @@ XRTpy v0.2.0 (2023-03-16)
 Deprecations and Removals
 -------------------------
 
-- Fixed time handling in contamination calculations using `astropy.time`.
+- Fixed time handling in contamination calculations using ``astropy.time``.
   (:pr:`104`)
-
 
 Features
 --------
 
-- Derived temperature and emission measure for a pair of images,
-  `xrtpy.response.xrt_teem.xrt_teem`. (:pr:`89`)
-
+- Added routine ``xrt_teem`` to derive temperatures and emission
+  measures from pairs of images using the filter ratio method. (:pr:`89`)
 
 Bug Fixes
 ---------
 
-- Addressed and fixed the temperature response 'NAN' calculations output.
+- Addressed and fixed the temperature response ``nan`` calculations output.
   (:pr:`111`)
-
 
 Improved Documentation
 ----------------------

--- a/docs/changelog/0.2.0.rst
+++ b/docs/changelog/0.2.0.rst
@@ -1,0 +1,30 @@
+XRTpy v0.2.0 (2023-03-16)
+=========================
+
+Deprecations and Removals
+-------------------------
+
+- Fixed time handling in contamination calculations using `astropy.time`.
+  (:pr:`104`)
+
+
+Features
+--------
+
+- Derived temperature and emission measure for a pair of images,
+  `xrtpy.response.xrt_teem.xrt_teem`. (:pr:`89`)
+
+
+Bug Fixes
+---------
+
+- Addressed and fixed the temperature response 'NAN' calculations output.
+  (:pr:`111`)
+
+
+Improved Documentation
+----------------------
+
+- Updated temperature response example notebook. (:pr:`94`)
+- Updated effective area example notebook. (:pr:`102`)
+- Added a changelog. (:pr:`128`)

--- a/docs/changelog/index.rst
+++ b/docs/changelog/index.rst
@@ -12,3 +12,4 @@ including bug fixes and changes to the application programming interface
    :maxdepth: 1
 
    dev
+   0.2.0

--- a/docs/changelog/index.rst
+++ b/docs/changelog/index.rst
@@ -11,5 +11,4 @@ including bug fixes and changes to the application programming interface
 .. toctree::
    :maxdepth: 1
 
-   dev
    0.2.0


### PR DESCRIPTION
In the top-level directory, I ran:

```bash
towncrier build --version=0.2.0
```

That created `CHANGELOG.rst` at the top-level. Then I did:

```bash
mv CHANGELOG.rst docs/changelog/0.2.0.rst
```
and added `0.2.0` to the `toctree` in `docs/changelog/index.rst`.  Might also need to remove `dev` from that too, but hopefully not.