### PR TITLE
Fix metadata for emission measure maps in xrt_teem

### DIFF
--- a/xrtpy/response/xrt_teem.py
+++ b/xrtpy/response/xrt_teem.py
@@ -705,12 +705,12 @@ def make_results_maps(hdr1, hdr2, T_e, EM, T_error, EMerror, mask):
     Tmap = Map(T_e, Thdr)
     Tmap.nickname = "Log Derived Temperature (K)"
     EMhdr = new_hdr.copy()
-    EMhdr["BUNIT"] = r"log10(cm$^{-3}$)"
+    EMhdr["BUNIT"] = r"log10(cm$^{{-3}}$)"
     EMhdr["history"] = (
         new_hdr["history"] + "Volume emission measure derived using filter ratio method"
     )
     EMmap = Map(EM, EMhdr)
-    EMmap.nickname = r"Log Derived Volume E.M. (cm$^{-3}$)"
+    EMmap.nickname = r"Log Derived Volume E.M. (cm$^{{-3}}$)"
     Terrhdr = new_hdr.copy()
     Terrhdr["BUNIT"] = "log10(K)"
     Terrhdr["history"] = (
@@ -719,13 +719,13 @@ def make_results_maps(hdr1, hdr2, T_e, EM, T_error, EMerror, mask):
     Terrmap = Map(T_error, Terrhdr)
     Terrmap.nickname = "Log Derived Temperature Errors (K)"
     EMerrhdr = new_hdr.copy()
-    EMerrhdr["BUNIT"] = r"log10(cm$^{-3}$)"
+    EMerrhdr["BUNIT"] = r"log10(cm$^{{-3}}$)"
     EMerrhdr["history"] = (
         new_hdr["history"]
         + "Volume emission measure uncertainty derived using filter ratio method"
     )
     EMerrmap = Map(EMerror, EMerrhdr)
-    EMerrmap.nickname = r"Log Derived V.E.M. Errors (cm$^{-3}$)"
+    EMerrmap.nickname = r"Log Derived V.E.M. Errors (cm$^{{-3}}$)"
     return Tmap, EMmap, Terrmap, EMerrmap
 
 


### PR DESCRIPTION
The {}s in the BUNIT and nickname metadata for the volume emission measure map and associated error map caused an error when the map.name attribute was instantiated. By replacing the {}s with {{}}s the error is avoided.