### PR TITLE
Add `ruff` to `pre-commit`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,6 +25,12 @@ repos:
   hooks:
   - id: pyproject-fmt
 
+- repo: https://github.com/charliermarsh/ruff-pre-commit
+  rev: v0.0.263
+  hooks:
+  - id: ruff
+    args: [--fix]
+
 - repo: https://github.com/PyCQA/isort
   rev: 5.12.0
   hooks:
@@ -46,7 +52,7 @@ repos:
   hooks:
   - id: nbqa-black
     additional_dependencies:
-    - black==23.1.0
+    - black==23.3.0
     args:
     - --nbqa-mutate
   - id: nbqa-isort

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,12 +34,28 @@ enabled = true
 
 [tool.ruff]
 target-version = "py39"
+show-fixes = true
 extend-select = [
   "UP",
 ]
 ignore = [
   "E501",
 ]
+extend-exclude = [
+  ".jupyter",
+  "__pycache__",
+  "_build",
+  "_dev",
+]
+
+[tool.ruff.flake8-import-conventions.aliases]
+"astropy.units" = "u"
+"matplotlib.pyplot" = "plt"
+numpy = "np"
+pandas = "pd"
+
+[tool.ruff.per-file-ignores]
+"__init__.py" = ["E402", "F401", "F402", "F403"]  # ignore import errors
 
 [tool.towncrier]
 package = "xrtpy"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,15 @@ te
 [tool.gilesbot.pull_requests]
 enabled = true
 
+[tool.ruff]
+target-version = "py39"
+extend-select = [
+  "UP",
+]
+ignore = [
+  "E501",
+]
+
 [tool.towncrier]
 package = "xrtpy"
 name = "XRTpy"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ enabled = true
 target-version = "py39"
 show-fixes = true
 extend-select = [
-  "UP",
+  "UP", # pyupgrade
 ]
 ignore = [
   "E501",

--- a/xrtpy/__init__.py
+++ b/xrtpy/__init__.py
@@ -9,7 +9,7 @@ import warnings
 from xrtpy import response
 
 try:
-    from xrtpy.version import __version__
+    from xrtpy.version import __version__  # noqa
 except ImportError:
     warnings.warn("version not found.")
 

--- a/xrtpy/response/channel.py
+++ b/xrtpy/response/channel.py
@@ -11,7 +11,6 @@ __all__ = [
 ]
 
 import numpy as np
-import scipy.io
 import sunpy.io.special
 import sunpy.time
 

--- a/xrtpy/response/tests/test_channel.py
+++ b/xrtpy/response/tests/test_channel.py
@@ -734,10 +734,6 @@ def test_ccd_gain_right(channel_name):
     channel_filter = Channel(channel_name)
     ccd_gain_right = channel_filter.ccd.ccd_gain_right
 
-    idl_ccd_gain_right_auto = v6_genx_s[_channel_name_to_index_mapping[channel_name]][ # noqa
-        "CCD"
-    ]["GAIN_R"] * (u.electron / u.DN)
-
     idl_ccd_gain_right_correction = 57.5 * (u.electron / u.DN)
 
     assert u.isclose(ccd_gain_right, idl_ccd_gain_right_correction)

--- a/xrtpy/response/tests/test_channel.py
+++ b/xrtpy/response/tests/test_channel.py
@@ -734,9 +734,9 @@ def test_ccd_gain_right(channel_name):
     channel_filter = Channel(channel_name)
     ccd_gain_right = channel_filter.ccd.ccd_gain_right
 
-    idl_ccd_gain_right_auto = v6_genx_s[_channel_name_to_index_mapping[channel_name]][
-        "CCD"
-    ]["GAIN_R"] * (u.electron / u.DN)
+    v6_genx_s[_channel_name_to_index_mapping[channel_name]]["CCD"]["GAIN_R"] * (
+        u.electron / u.DN
+    )
 
     idl_ccd_gain_right_correction = 57.5 * (u.electron / u.DN)
 

--- a/xrtpy/response/tests/test_channel.py
+++ b/xrtpy/response/tests/test_channel.py
@@ -734,9 +734,9 @@ def test_ccd_gain_right(channel_name):
     channel_filter = Channel(channel_name)
     ccd_gain_right = channel_filter.ccd.ccd_gain_right
 
-    v6_genx_s[_channel_name_to_index_mapping[channel_name]]["CCD"]["GAIN_R"] * (
-        u.electron / u.DN
-    )
+    idl_ccd_gain_right_auto = v6_genx_s[_channel_name_to_index_mapping[channel_name]][ # noqa
+        "CCD"
+    ]["GAIN_R"] * (u.electron / u.DN)
 
     idl_ccd_gain_right_correction = 57.5 * (u.electron / u.DN)
 

--- a/xrtpy/response/tests/test_channel.py
+++ b/xrtpy/response/tests/test_channel.py
@@ -841,7 +841,7 @@ def test_CCD_wavelength(channel_name):
 
 
 @pytest.mark.parametrize("channel_name", channel_names)
-def test_channel_name(channel_name):
+def test_channel_name2(channel_name):
     channel_filter = Channel(channel_name)
     name = channel_filter.name
 

--- a/xrtpy/response/tests/test_effective_area.py
+++ b/xrtpy/response/tests/test_effective_area.py
@@ -1,4 +1,3 @@
-import glob
 import pytest
 
 from astropy import units as u

--- a/xrtpy/response/tests/test_temperature_response.py
+++ b/xrtpy/response/tests/test_temperature_response.py
@@ -1,4 +1,3 @@
-import glob
 import pytest
 
 from datetime import datetime

--- a/xrtpy/response/tests/test_temperature_response_coronal.py
+++ b/xrtpy/response/tests/test_temperature_response_coronal.py
@@ -1,4 +1,3 @@
-import glob
 import pytest
 
 from datetime import datetime

--- a/xrtpy/response/tests/test_temperature_response_hybrid.py
+++ b/xrtpy/response/tests/test_temperature_response_hybrid.py
@@ -1,6 +1,3 @@
-import glob
-import numpy as np
-import os
 import pytest
 
 from datetime import datetime

--- a/xrtpy/response/tests/test_temperature_response_photospheric.py
+++ b/xrtpy/response/tests/test_temperature_response_photospheric.py
@@ -1,6 +1,3 @@
-import glob
-import numpy as np
-import os
 import pytest
 
 from datetime import datetime

--- a/xrtpy/response/tests/test_xrt_teem.py
+++ b/xrtpy/response/tests/test_xrt_teem.py
@@ -1,8 +1,6 @@
 import numpy as np
-import pytest
 import sunpy.map
 
-from astropy.io import fits
 from pathlib import Path
 from scipy.io import readsav
 
@@ -128,8 +126,8 @@ def test_binning_case():
     goodT = (T_e.data > 0.0) & (idlTe > 0.0)
     goodE = (EM.data > 0.0) & (idlEM > 0.0)
 
-    delta = 10.0 ** T_e.data[goodT] - 10.0 ** idlTe[goodT]
-    x = 10.0 ** idlTe[goodT]
+    10.0 ** T_e.data[goodT] - 10.0 ** idlTe[goodT]
+    10.0 ** idlTe[goodT]
 
     assert np.allclose(
         10.0 ** T_e.data[goodT], 10.0 ** idlTe[goodT], atol=2.0e5, rtol=0.02

--- a/xrtpy/response/xrt_teem.py
+++ b/xrtpy/response/xrt_teem.py
@@ -5,7 +5,6 @@ ratio technique.
 __all__ = ["xrt_teem"]
 
 import numpy as np
-import sys
 
 from astropy import units as u
 from astropy.constants import c, h

--- a/xrtpy/util/__init__.py
+++ b/xrtpy/util/__init__.py
@@ -1,5 +1,7 @@
+from xrtpy.util import time
 from xrtpy.util.time import epoch
 
 __all__ = [
     "epoch",
+    "time",
 ]

--- a/xrtpy/util/__init__.py
+++ b/xrtpy/util/__init__.py
@@ -1,4 +1,3 @@
-from xrtpy.util import time
 from xrtpy.util.time import epoch
 
 __all__ = [

--- a/xrtpy/util/tests/test_xrt_deconvolve.py
+++ b/xrtpy/util/tests/test_xrt_deconvolve.py
@@ -1,6 +1,5 @@
 import numpy as np
 import pkg_resources
-import pytest
 
 from pathlib import Path
 from sunpy.map import Map

--- a/xrtpy/util/xrt_deconvolve.py
+++ b/xrtpy/util/xrt_deconvolve.py
@@ -4,9 +4,7 @@ Functionality for deconvolving XRT image data with the point spread function.
 __all__ = ["xrt_deconvolve"]
 
 import numpy as np
-import os
 
-from astropy.io import fits
 from datetime import datetime
 from numpy.fft import fft2, fftshift, ifft2
 from pathlib import Path


### PR DESCRIPTION
[`ruff`](https://beta.ruff.rs/docs/) is a new Python linter, which is really fast because it is written in Rust instead of Python.  `ruff` has a bunch of linter rules for `flake8` already built in, plus the rules for a lot of `flake8` extensions.  Unlike `flake8`, `ruff` is able to automagically fix a wide variety of linter errors.  In the future, we should be able to drop `flake8` and use `ruff` instead.

This PR adds a pre-commit hook for `ruff`, and makes some automatic fixes.