### PR TITLE
Add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,58 @@
+name: 🐛 Bug Report
+description: Report a problem that you encountered when using PlasmaPy
+labels: [Bug]
+body:
+
+- type: markdown
+  attributes:
+    value: >
+      Thank you for submitting a bug report — we really appreciate it!
+
+- type: textarea
+  id: description
+  attributes:
+    label: Bug description
+    description: >
+      Please describe what you were doing and what went wrong.
+  validations:
+    required: true
+
+- type: textarea
+  id: expected-outcome
+  attributes:
+    label: Expected outcome
+    description: >
+      What did you expect to happen instead? (optional)
+  validations:
+    required: false
+
+- type: textarea
+  id: minimal-example
+  attributes:
+    label: Minimal complete verifiable example
+    description: >
+      Provide a minimal self-contained example to help us reproduce the
+      bug, along with any relevant output. This will be automatically
+      formatted into code, so no need for Markdown backticks. (optional,
+      but incredibly helpful!)
+    render: Python
+  validations:
+    required: false
+
+- type: textarea
+  id: package-versions
+  attributes:
+    label: Package versions
+    description: >
+      What version of PlasmaPy (`plasmapy.__version__`) were you using
+      when the problem occurred? (optional)
+
+- type: textarea
+  id: context
+  attributes:
+    label: Additional context
+    description: >
+      Please provide any additional context that would help us
+      understand and fix the bug. (optional)
+  validations:
+    required: false

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,5 +1,5 @@
 name: 🐛 Bug Report
-description: Report a problem that you encountered when using PlasmaPy
+description: Report a problem that you encountered when using XRTpy
 labels: [Bug]
 body:
 
@@ -38,14 +38,6 @@ body:
     render: Python
   validations:
     required: false
-
-- type: textarea
-  id: package-versions
-  attributes:
-    label: Package versions
-    description: >
-      What version of PlasmaPy (`plasmapy.__version__`) were you using
-      when the problem occurred? (optional)
 
 - type: textarea
   id: context

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,6 @@
 name: 💡 Feature Request
 description: |
-  Help shape the future of PlasmaPy by requesting a new feature
+  Help shape the future of XRTpy by requesting a new feature
 labels: [Feature request]
 body:
 - type: textarea
@@ -8,7 +8,7 @@ body:
   attributes:
     label: Feature description
     description: >
-      What new capability would you like added to PlasmaPy?
+      What new capability would you like added to XRTpy?
   validations:
     required: true
 

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,39 @@
+name: 💡 Feature Request
+description: |
+  Help shape the future of PlasmaPy by requesting a new feature
+labels: [Feature request]
+body:
+- type: textarea
+  id: description
+  attributes:
+    label: Feature description
+    description: >
+      What new capability would you like added to PlasmaPy?
+  validations:
+    required: true
+
+- type: textarea
+  id: motivation
+  attributes:
+    label: Motivation
+    description: >
+      What are the benefits from adding this feature? What problems or
+      limitations would be solved? (optional)
+
+- type: textarea
+  id: solution
+  attributes:
+    label: Implementation strategy
+    description: >
+      How might we go about implementing this new capability? (optional)
+  validations:
+    required: false
+
+- type: textarea
+  id: additional-context
+  attributes:
+    label: Additional context
+    description: >
+      Please provide any additional helpful details here. (optional)
+  validations:
+    required: false

--- a/.github/ISSUE_TEMPLATE/general_issue.yml
+++ b/.github/ISSUE_TEMPLATE/general_issue.yml
@@ -1,0 +1,11 @@
+name: 📝 General Issue
+description: Create an issue that doesn't fit in the other categories
+body:
+- type: textarea
+  id: description
+  attributes:
+    label: Description
+    description: >
+      Please describe the issue here.
+  validations:
+    required: true


### PR DESCRIPTION
This PR adapts templates from PlasmaPy for creating issues. To get a preview of how these would work, check out the [new issue page for PlasmaPy](https://github.com/PlasmaPy/PlasmaPy/issues/new/choose).