### PR TITLE
Update Read the Docs configuration file

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,14 +9,12 @@ formats:
 build:
   os: ubuntu-22.04
   tools:
-    python: '3.10'
+    python: '3.11'
   apt_packages:
   - graphviz
   jobs:
-    pre_create_environment:
-    - python -m pip install --upgrade setuptools pip
     post_build:
-    - echo https://docs.plasmapy.org/en/latest/contributing/doc_guide.html#troubleshooting
+    - echo $'\n'For help deciphering documentation build error messages, see:$'\n\n'\ \ https://docs.plasmapy.org/en/latest/contributing/doc_guide.html#troubleshooting
 
 python:
   install:
@@ -24,4 +22,3 @@ python:
     path: .
     extra_requirements:
     - docs
-  system_packages: true

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -14,6 +14,7 @@ Getting started
 
 .. nbgallery::
   :glob:
+
   notebooks/getting_started/*
 
 Computing response functions


### PR DESCRIPTION
Our Read the Docs configuration became out-of-date and stopped working. This PR copies over some YAML magic from PlasmaPy's RTD config file to make things work again.