### PR TITLE
Set upper limit on version of `nbconvert`

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -89,10 +89,15 @@ jobs:
       run: python -m pip install --progress-bar off --upgrade nox
 
     - name: Install graphviz
-      run: brew install graphviz
+      run: sudo apt install graphviz
 
     - name: Install pandoc
-      run: brew install pandoc
+      run: |
+        PANDOC_VERSION="3.1.11.1"
+        wget -q https://github.com/jgm/pandoc/releases/download/${PANDOC_VERSION}/pandoc-${PANDOC_VERSION}-1-amd64.deb
+        sudo dpkg -i pandoc-${PANDOC_VERSION}-1-amd64.deb
+        rm pandoc-${PANDOC_VERSION}-1-amd64.deb
+        pandoc --version
 
     - name: Build documentation
       run: nox -e build_docs_nitpicky -- -q

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -89,15 +89,10 @@ jobs:
       run: python -m pip install --progress-bar off --upgrade nox
 
     - name: Install graphviz
-      run: sudo apt install graphviz
+      run: brew install graphviz
 
     - name: Install pandoc
-      run: |
-        PANDOC_VERSION="3.1.11.1"
-        wget -q https://github.com/jgm/pandoc/releases/download/${PANDOC_VERSION}/pandoc-${PANDOC_VERSION}-1-amd64.deb
-        sudo dpkg -i pandoc-${PANDOC_VERSION}-1-amd64.deb
-        rm pandoc-${PANDOC_VERSION}-1-amd64.deb
-        pandoc --version
+      run: brew install pandoc
 
     - name: Build documentation
       run: nox -e build_docs_nitpicky -- -q

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -62,7 +62,7 @@ jobs:
 
   documentation:
     name: ${{ matrix.name }}
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
 
     strategy:
       fail-fast: false

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -71,7 +71,7 @@ jobs:
         include:
 
         - name: Documentation
-          python: '3.10'
+          python: '3.12'
 
     steps:
 
@@ -88,8 +88,19 @@ jobs:
     - name: Install nox
       run: python -m pip install --progress-bar off --upgrade nox
 
-    - name: Install graphviz and pandoc
-      run: sudo apt install graphviz pandoc
+    - name: Install graphviz
+      run: sudo apt install graphviz
+
+    - name: Install pandoc
+      run: |
+        # Specify the desired version of Pandoc
+        PANDOC_VERSION="3.1.11.1" # Update this to the version you need
+        # Download the pre-built binary package for Linux
+        wget https://github.com/jgm/pandoc/releases/download/${PANDOC_VERSION}/pandoc-${PANDOC_VERSION}-1-amd64.deb
+        # Install the downloaded package
+        sudo dpkg -i pandoc-${PANDOC_VERSION}-1-amd64.deb
+        # Remove the downloaded package file
+        rm pandoc-${PANDOC_VERSION}-1-amd64.deb
 
     - name: Build documentation
       run: nox -e build_docs_nitpicky -- -q

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -62,7 +62,7 @@ jobs:
 
   documentation:
     name: ${{ matrix.name }}
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false

--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,7 @@ target/
 # IPython
 profile_default/
 ipython_config.py
+Untitled*.ipynb
 
 # pyenv
 .python-version

--- a/docs/notebooks/data_analysis/Deconvolving_XRT_images.ipynb
+++ b/docs/notebooks/data_analysis/Deconvolving_XRT_images.ipynb
@@ -116,7 +116,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.1"
+   "version": "3.11.0"
   }
  },
  "nbformat": 4,

--- a/docs/notebooks/data_analysis/Deconvolving_XRT_images.ipynb
+++ b/docs/notebooks/data_analysis/Deconvolving_XRT_images.ipynb
@@ -98,14 +98,6 @@
     "fig.subplots_adjust(wspace=0.5)\n",
     "plt.show()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "549d08ea",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -124,7 +116,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.0"
+   "version": "3.12.1"
   }
  },
  "nbformat": 4,

--- a/docs/notebooks/data_analysis/Remove_lightleak.ipynb
+++ b/docs/notebooks/data_analysis/Remove_lightleak.ipynb
@@ -149,7 +149,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.1"
+   "version": "3.11.0"
   }
  },
  "nbformat": 4,

--- a/docs/notebooks/data_analysis/Remove_lightleak.ipynb
+++ b/docs/notebooks/data_analysis/Remove_lightleak.ipynb
@@ -5,7 +5,7 @@
    "id": "075bbcc4",
    "metadata": {},
    "source": [
-    "# Remove lightleaks to analyze XRT composite images"
+    "# Using the `remove_lightleak` function to analyze XRT composite images"
    ]
   },
   {

--- a/docs/notebooks/data_analysis/Remove_lightleak.ipynb
+++ b/docs/notebooks/data_analysis/Remove_lightleak.ipynb
@@ -5,7 +5,7 @@
    "id": "075bbcc4",
    "metadata": {},
    "source": [
-    "# Using the remove_lightleak function to analyze XRT composite images"
+    "# Remove lightleaks to analyze XRT composite images"
    ]
   },
   {

--- a/docs/notebooks/data_analysis/Remove_lightleak.ipynb
+++ b/docs/notebooks/data_analysis/Remove_lightleak.ipynb
@@ -131,14 +131,6 @@
     "fig.subplots_adjust(wspace=0.5)\n",
     "plt.show()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "eda9e234",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -157,7 +149,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.0"
+   "version": "3.12.1"
   }
  },
  "nbformat": 4,

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -8,6 +8,7 @@ docutils >= 0.18
 ipykernel
 ipython
 jinja2 != 3.1
+nbconvert < 7.14
 nbsphinx >= 0.9
 numpydoc >= 1.2
 pillow

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -8,7 +8,7 @@ docutils >= 0.18
 ipykernel
 ipython
 jinja2 != 3.1
-nbconvert < 7.14
+nbconvert
 nbsphinx >= 0.9
 numpydoc >= 1.2
 pillow

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -8,7 +8,7 @@ docutils >= 0.18
 ipykernel
 ipython
 jinja2 != 3.1
-nbconvert
+nbconvert < 7.14
 nbsphinx >= 0.9
 numpydoc >= 1.2
 pillow

--- a/setup.cfg
+++ b/setup.cfg
@@ -64,7 +64,7 @@ docs =
     ipykernel
     ipython
     jinja2 != 3.1
-    nbconvert
+    nbconvert < 7.14
     nbsphinx >= 0.9
     numpydoc >= 1.2
     pillow

--- a/setup.cfg
+++ b/setup.cfg
@@ -64,7 +64,7 @@ docs =
     ipykernel
     ipython
     jinja2 != 3.1
-    nbconvert < 7.14
+    nbconvert
     nbsphinx >= 0.9
     numpydoc >= 1.2
     pillow

--- a/setup.cfg
+++ b/setup.cfg
@@ -64,6 +64,7 @@ docs =
     ipykernel
     ipython
     jinja2 != 3.1
+    nbconvert < 7.14
     nbsphinx >= 0.9
     numpydoc >= 1.2
     pillow


### PR DESCRIPTION
This PR is to address the following error that started showing up multiple times in our documentation builds:

```
/home/runner/work/xrtpy/xrtpy/docs/notebooks/data_analysis/Deconvolving_XRT_images.ipynb:137: ERROR: Content block expected for the "raw" directive; none found.
```

I was able to resolve the error by requiring `nbconvert < 7.14`.  I also tried changing the OS in the GitHub Action from `ubuntu-latest` to `macos-latest` and upgrading to the most recent version of `pandoc`, but neither of those changes got rid of the error.