### PR TITLE
Add ipywidgets to docs requirements

### DIFF
--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -7,6 +7,7 @@
 docutils >= 0.18
 ipykernel
 ipython
+ipywidgets
 jinja2 != 3.1
 nbconvert < 7.14
 nbsphinx >= 0.9


### PR DESCRIPTION
This should mean you get pretty progress bars and no warnings in your docs builds.