### PR TITLE
Updated notebook with improved sunpy map import method

### DIFF
--- a/docs/notebooks/data_analysis/Deconvolving_XRT_images.ipynb
+++ b/docs/notebooks/data_analysis/Deconvolving_XRT_images.ipynb
@@ -31,12 +31,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from sunpy.map import Map\n",
+    "import matplotlib.pyplot as plt\n",
+    "import sunpy.map\n",
     "from sunpy.net import Fido\n",
     "from sunpy.net import attrs as a\n",
     "\n",
     "from xrtpy.image_correction.deconvolve import deconvolve\n",
     "\n",
+    "# Search for the data with a define time range and instrument\n",
     "result = Fido.search(\n",
     "    a.Time(\"2012-06-05 21:58:39\", \"2012-06-05 21:59:00\"), a.Instrument(\"xrt\")\n",
     ")\n",
@@ -59,7 +61,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "in_map = Map(data_file)\n",
+    "# Create sunpy map from the fetched data\n",
+    "in_map = sunpy.map.Map(data_file)\n",
+    "\n",
+    "# Apply xrtpy deconvolution\n",
     "out_map = deconvolve(in_map)"
    ]
   },
@@ -80,9 +85,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import matplotlib.pyplot as plt\n",
-    "\n",
-    "fig = plt.figure()\n",
+    "# Plotting the original and deconvolved images\n",
+    "fig = plt.figure(figsize=(10, 5))\n",
     "ax1 = fig.add_subplot(1, 2, 1, projection=in_map)\n",
     "in_map.plot(axes=ax1, title=\"Original Image\")\n",
     "ax2 = fig.add_subplot(1, 2, 2, projection=out_map)\n",
@@ -108,7 +112,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.0"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR updates the import method for SunPy maps in the Deconvolving_XRT_images.ipynb notebook to align with the way it's imported in other notebooks, consistency. Addressing issue #237 .