### PR TITLE
Fix Deriving temperatures using composite images and the filter ratio method notebook error

### DIFF
--- a/docs/notebooks/data_analysis/Temperature_using_composites.ipynb
+++ b/docs/notebooks/data_analysis/Temperature_using_composites.ipynb
@@ -43,21 +43,59 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ef4d8a39",
+   "id": "40b68a5b",
    "metadata": {},
    "outputs": [],
    "source": [
-    "from astropy.utils.data import download_file\n",
-    "\n",
+    "from astropy.utils.data import download_file"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ed0d2edc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "from xrtpy.response.temperature_from_filter_ratio import temperature_from_filter_ratio\n",
-    "from xrtpy.util.filename2repo_path import filename2repo_path\n",
-    "\n",
+    "from xrtpy.util.filename2repo_path import filename2repo_path"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7540646f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Define filenames\n",
     "filename1 = \"comp_XRT20210730_175810.1.fits\"\n",
-    "filename2 = \"comp_XRT20210730_175831.6.fits\"\n",
+    "filename2 = \"comp_XRT20210730_175831.6.fits\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "17c6d3b0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Convert filenames to URLs\n",
     "url1 = filename2repo_path(filename1, join=True)\n",
-    "url2 = filename2repo_path(filename2, join=True)\n",
+    "url2 = filename2repo_path(filename2, join=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e5e9bf14",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# These files will go under your astropy cache directory, typically ~/.astropy/cache/download/url/\n",
-    "file1 = download_file(url1)\n",
+    "file1 = download_file(\n",
+    "    url1,\n",
+    ")\n",
     "file2 = download_file(url2)"
    ]
   },

--- a/docs/notebooks/data_analysis/Using_temperature_from_filter_ratio.ipynb
+++ b/docs/notebooks/data_analysis/Using_temperature_from_filter_ratio.ipynb
@@ -40,7 +40,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "b0dbae75",
    "metadata": {},
    "outputs": [],
@@ -54,7 +54,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "da83268f",
    "metadata": {},
    "outputs": [],
@@ -223,14 +223,6 @@
     "\n",
     "These data were analyzed by [Guidoni et al. (2015, ApJ 800, 54)]. See also [Narukage et al. (2014, Solar Phys. 289, 1029)]. "
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "9fb5dcfa-f5c8-4a80-bf8e-442afe4916b6",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
Fixing verification of TLS/SSL certificate for notebook example, Deriving temperatures using composite images and the filter ratio method.