### PR TITLE
Create documentation stub files

### DIFF
--- a/docs/api_static/xrtpy.image_correction.deconvolve.rst
+++ b/docs/api_static/xrtpy.image_correction.deconvolve.rst
@@ -1,0 +1,8 @@
+:orphan:
+
+`xrtpy.image_correction.deconvolve`
+===================================
+
+.. currentmodule:: xrtpy.image_correction.deconvolve
+
+.. automodapi:: xrtpy.image_correction.deconvolve

--- a/docs/api_static/xrtpy.image_correction.rst
+++ b/docs/api_static/xrtpy.image_correction.rst
@@ -1,0 +1,8 @@
+:orphan:
+
+`xrtpy.image_correction`
+========================
+
+.. currentmodule:: xrtpy.image_correction
+
+.. automodapi:: xrtpy.image_correction

--- a/docs/api_static/xrtpy.response.temperature_response.rst
+++ b/docs/api_static/xrtpy.response.temperature_response.rst
@@ -1,0 +1,8 @@
+:orphan:
+
+`xrtpy.response.temperature_response`
+=====================================
+
+.. currentmodule:: xrtpy.response.temperature_response
+
+.. automodapi:: xrtpy.response.temperature_response

--- a/docs/api_static/xrtpy.util.make_exposure_map.rst
+++ b/docs/api_static/xrtpy.util.make_exposure_map.rst
@@ -5,4 +5,4 @@
 
 .. currentmodule:: xrtpy.util.make_exposure_map
 
-.. automodapi:: xrtpy.response.make_exposure_map
+.. automodapi:: xrtpy.util.make_exposure_map

--- a/docs/api_static/xrtpy.util.make_exposure_map.rst
+++ b/docs/api_static/xrtpy.util.make_exposure_map.rst
@@ -1,0 +1,8 @@
+:orphan:
+
+`xrtpy.util.make_exposure_map`
+==============================
+
+.. currentmodule:: xrtpy.util.make_exposure_map
+
+.. automodapi:: xrtpy.response.make_exposure_map

--- a/docs/api_static/xrtpy.util.rst
+++ b/docs/api_static/xrtpy.util.rst
@@ -1,0 +1,8 @@
+:orphan:
+
+`xrtpy.util`
+============
+
+.. currentmodule:: xrtpy.util
+
+.. automodapi:: xrtpy.util

--- a/docs/api_static/xrtpy.util.time.rst
+++ b/docs/api_static/xrtpy.util.time.rst
@@ -1,0 +1,8 @@
+:orphan:
+
+`xrtpy.util.time`
+=================
+
+.. currentmodule:: xrtpy.util.time
+
+.. automodapi:: xrtpy.util.time

--- a/xrtpy/image_correction/__init__.py
+++ b/xrtpy/image_correction/__init__.py
@@ -5,6 +5,8 @@ __all__ = [
     "remove_lightleak",
 ]
 
+from xrtpy.image_correction import deconvolve, remove_lightleak
+
 _SSW_MIRRORS = [
     "https://sohoftp.nascom.nasa.gov/solarsoft/",
     "https://hesperia.gsfc.nasa.gov/ssw/",

--- a/xrtpy/image_correction/__init__.py
+++ b/xrtpy/image_correction/__init__.py
@@ -6,8 +6,3 @@ __all__ = [
 ]
 
 from xrtpy.image_correction import deconvolve, remove_lightleak
-
-_SSW_MIRRORS = [
-    "https://sohoftp.nascom.nasa.gov/solarsoft/",
-    "https://hesperia.gsfc.nasa.gov/ssw/",
-]

--- a/xrtpy/image_correction/_ssw_mirrors.py
+++ b/xrtpy/image_correction/_ssw_mirrors.py
@@ -1,0 +1,8 @@
+"""Mirrors of SolarSoft IDL."""
+
+__all__ = []
+
+_SSW_MIRRORS = [
+    "https://sohoftp.nascom.nasa.gov/solarsoft/",
+    "https://hesperia.gsfc.nasa.gov/ssw/",
+]

--- a/xrtpy/image_correction/_ssw_mirrors.py
+++ b/xrtpy/image_correction/_ssw_mirrors.py
@@ -1,8 +1,0 @@
-"""Mirrors of SolarSoft IDL."""
-
-__all__ = []
-
-_SSW_MIRRORS = [
-    "https://sohoftp.nascom.nasa.gov/solarsoft/",
-    "https://hesperia.gsfc.nasa.gov/ssw/",
-]

--- a/xrtpy/image_correction/deconvolve.py
+++ b/xrtpy/image_correction/deconvolve.py
@@ -14,7 +14,7 @@ from sunpy.image.resample import resample
 from sunpy.image.transform import affine_transform
 from sunpy.map import Map
 
-from xrtpy.image_correction._ssw_mirrors import _SSW_MIRRORS
+from xrtpy.util import SSW_MIRRORS
 
 
 @manager.require(

--- a/xrtpy/image_correction/deconvolve.py
+++ b/xrtpy/image_correction/deconvolve.py
@@ -21,7 +21,7 @@ from xrtpy.util import SSW_MIRRORS
     "PSF560.fits",
     [
         urljoin(mirror, "hinode/xrt/idl/util/XRT20170324_151721.0.PSF560.fits")
-        for mirror in _SSW_MIRRORS
+        for mirror in SSW_MIRRORS
     ],
     "0eaa5da6fb69661e7f46d1f0c463e4b3b1745426a399a4fbc53fc0c0ae87dd0d",
 )
@@ -29,7 +29,7 @@ from xrtpy.util import SSW_MIRRORS
     "PSF1000.fits",
     [
         urljoin(mirror, "hinode/xrt/idl/util/XRT20170324_161721.0.PSF1000.fits")
-        for mirror in _SSW_MIRRORS
+        for mirror in SSW_MIRRORS
     ],
     "95590a7174692977a2f111b932811c9c7ae105a59b93bfe6c96fba862cefacf1",
 )

--- a/xrtpy/image_correction/remove_lightleak.py
+++ b/xrtpy/image_correction/remove_lightleak.py
@@ -11,7 +11,7 @@ from sunpy.data import manager
 from sunpy.map import Map
 from sunpy.time import parse_time
 
-from xrtpy.image_correction._ssw_mirrors import _SSW_MIRRORS
+from xrtpy.util import SSW_MIRRORS
 
 __all__ = ["remove_lightleak"]
 

--- a/xrtpy/image_correction/remove_lightleak.py
+++ b/xrtpy/image_correction/remove_lightleak.py
@@ -11,7 +11,7 @@ from sunpy.data import manager
 from sunpy.map import Map
 from sunpy.time import parse_time
 
-from xrtpy.image_correction import _SSW_MIRRORS
+from xrtpy.image_correction._ssw_mirrors import _SSW_MIRRORS
 
 __all__ = ["remove_lightleak"]
 

--- a/xrtpy/image_correction/remove_lightleak.py
+++ b/xrtpy/image_correction/remove_lightleak.py
@@ -2,6 +2,8 @@
 Functionality for removing the visible light leak from XRT composite image data.
 """
 
+__all__ = ["remove_lightleak"]
+
 import warnings
 from urllib.parse import urljoin
 
@@ -12,8 +14,6 @@ from sunpy.map import Map
 from sunpy.time import parse_time
 
 from xrtpy.util import SSW_MIRRORS
-
-__all__ = ["remove_lightleak"]
 
 LL_FILE_HASHES = {
     "term_p1cp_20140527_204601.fits": "bdb924a6ae62292980b266cec0fb96c3626d921efe8148a13b26f964513ea533",

--- a/xrtpy/image_correction/remove_lightleak.py
+++ b/xrtpy/image_correction/remove_lightleak.py
@@ -216,7 +216,7 @@ def remove_lightleak(in_map, scale=1.0, leak_map=None):
             "ll_file",
             [
                 urljoin(mirror, f"hinode/xrt/idl/util/leak_fits/{leak_filename}")
-                for mirror in _SSW_MIRRORS
+                for mirror in SSW_MIRRORS
             ],
             LL_FILE_HASHES[leak_filename],
         )

--- a/xrtpy/util/__init__.py
+++ b/xrtpy/util/__init__.py
@@ -1,12 +1,15 @@
-from xrtpy.util import time
+from xrtpy.util import time, filename2repo_path, make_exposure_map
 from xrtpy.util.time import epoch
 
 __all__ = [
     "epoch",
     "time",
+    "filename2repo_path",
+    "make_exposure_map",
+    "SSW_MIRRORS",
 ]
 
-_SSW_MIRRORS = [
+SSW_MIRRORS = (
     "https://sohoftp.nascom.nasa.gov/solarsoft/",
     "https://hesperia.gsfc.nasa.gov/ssw/",
-]
+)

--- a/xrtpy/util/__init__.py
+++ b/xrtpy/util/__init__.py
@@ -1,4 +1,4 @@
-from xrtpy.util import time, filename2repo_path, make_exposure_map
+from xrtpy.util import filename2repo_path, make_exposure_map, time
 from xrtpy.util.time import epoch
 
 __all__ = [

--- a/xrtpy/util/make_exposure_map.py
+++ b/xrtpy/util/make_exposure_map.py
@@ -9,6 +9,7 @@ from xrtpy.util.filename2repo_path import filename2repo_path
 
 __all__ = ["make_exposure_map"]
 
+
 def make_exposure_map(comp_image_file, qualfiles=None, retsatpix=False, verbose=False):
     """
     Make an exposure map for a composite image. That is, using data from the

--- a/xrtpy/util/make_exposure_map.py
+++ b/xrtpy/util/make_exposure_map.py
@@ -7,6 +7,7 @@ from astropy.utils.data import download_file
 
 from xrtpy.util.filename2repo_path import filename2repo_path
 
+__all__ = ["make_exposure_map"]
 
 def make_exposure_map(comp_image_file, qualfiles=None, retsatpix=False, verbose=False):
     """


### PR DESCRIPTION
This PR adds documentation stub files to `docs/api_static` to make sure that the modules show up in the documentation. The purpose of these stub files is to make sure that every module in `xrtpy` has a corresponding [`automodapi`](https://sphinx-automodapi.readthedocs.io/en/latest/automodapi.html) directive.  

More information on how and why to do this is in the [PlasmaPy doc guide](https://docs.plasmapy.org/en/latest/contributing/doc_guide.html#creating-a-documentation-stub-file-for-a-new-module). 

> [!NOTE]
> If we decide to create narrative documentation pages for the different subpackages at `docs/response.rst`, we'd need to delete the corresponding file in `docs/api_static/`.


