### PR TITLE
Consolidate initial and comprehensive tests

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -20,21 +20,31 @@ jobs:
       matrix:
         include:
 
-        - name: Python 3.11 (Windows)
-          os: windows-latest
-          noxenv: tests-3.11
-          python: '3.11'
-          noxposargs: --durations=10
-
         - name: Python 3.12 (Windows)
           os: windows-latest
           noxenv: tests-3.12
           python: '3.12'
           noxposargs: --durations=10
 
+        - name: Python 3.11 (Windows)
+          os: windows-latest
+          noxenv: tests-3.11
+          python: '3.11'
+          noxposargs: --durations=10
+
+        - name: Python 3.10 (Mac OS)
+          os: macos-latest
+          noxenv: tests-3.10
+          python: '3.10'
+
+        - name: Python 3.9 (Windows)
+          os: windows-latest
+          python: 3.9
+          noxenv: tests-3.9
+
         - name: Import package
           os: windows-latest
-          python: '3.11'
+          python: 3.9
           noxenv: import_package
 
     steps:
@@ -96,46 +106,3 @@ jobs:
 
     - name: Build documentation
       run: nox -e build_docs_nitpicky -- -q
-
-  comprehensive-tests:
-    name: ${{ matrix.name }}
-    runs-on: ${{ matrix.os }}
-    needs: initial-tests
-    strategy:
-      fail-fast: false
-
-      matrix:
-        include:
-
-        - name: Python 3.10 (Mac OS)
-          os: macos-latest
-          noxenv: tests-3.10
-          python: '3.10'
-
-        - name: Python 3.9 (Windows)
-          os: windows-latest
-          python: 3.9
-          noxenv: tests-3.9
-
-        - name: Import package
-          os: windows-latest
-          python: 3.9
-          noxenv: import_package
-
-    steps:
-
-    - name: Checkout code
-      uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
-
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: ${{ matrix.python }}
-
-    - name: Install nox
-      run: python -m pip install --progress-bar off --upgrade nox
-
-    - name: ${{ matrix.name }}
-      run: nox -s ${{ matrix.noxenv }} -- ${{ matrix.noxposargs }}

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -5,44 +5,48 @@ on:
     branches:
     - main
     - stable
-    - v*.*.x
+    - v*.*.*
+    tags:
+    - v*
   pull_request:
   workflow_dispatch:
 
 jobs:
 
-  initial-tests:
+  tests:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+
     strategy:
       fail-fast: false
 
       matrix:
         include:
 
-        - name: Python 3.12 (Windows)
+        - name: Tests, Python 3.12, Windows
           os: windows-latest
           noxenv: tests-3.12
           python: '3.12'
           noxposargs: --durations=10
 
-        - name: Python 3.11 (Windows)
+        - name: Tests, Python 3.11, Windows
           os: windows-latest
           noxenv: tests-3.11
           python: '3.11'
           noxposargs: --durations=10
 
-        - name: Python 3.10 (Mac OS)
+        - name: Tests, Python 3.10, macOS
           os: macos-latest
           noxenv: tests-3.10
           python: '3.10'
 
-        - name: Python 3.9 (Windows)
+        - name: Tests, Python 3.9, Windows
           os: windows-latest
           python: 3.9
           noxenv: tests-3.9
 
-        - name: Import package
+        - name: Import XRTpy, Python 3.9, Windows
           os: windows-latest
           python: 3.9
           noxenv: import_package
@@ -105,4 +109,4 @@ jobs:
         pandoc --version
 
     - name: Build documentation
-      run: nox -e build_docs_nitpicky -- -q
+      run: nox -s build_docs_nitpicky -- -q


### PR DESCRIPTION
Previously, we've been splitting up tests.  We ran the `initial-tests` first, and then the `comprehensive-tests` afterwards if the `initial-tests` pass.

This PR consolidates the initial and comprehensive tests so that we don't need to wait as long for all of the tests to finish.

I also am updating the names of the test sessions to be more consistent with the naming scheme in use for PlasmaPy.  If the renaming gets merged, we'll need to update the names of required tests for pull requests.