### PR TITLE
Add Code of Conduct to XRTpy

### DIFF
--- a/docs/CODE_OF_CONDUCT.rst
+++ b/docs/CODE_OF_CONDUCT.rst
@@ -40,6 +40,7 @@ in appropriate consequences, including warnings, temporary bans, or permanent re
 enforcing these rules and taking corrective action as needed.
 
 **Enforcement and Reporting**
+
 - Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at xrtpy@cfa.harvard.edu. All complaints will be reviewed and investigated promptly and fairly.
 - Community leaders are obligated to respect the privacy and security of the reporter of any incident.
 

--- a/docs/CODE_OF_CONDUCT.rst
+++ b/docs/CODE_OF_CONDUCT.rst
@@ -14,7 +14,7 @@ Our Pledge
 ==========
 We, as contributors and maintainers of XRTpy, pledge to make participation in our project and community a harassment-free
 experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of
-experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and
+experience, education, socioeconomic status, nationality, personal appearance, race, religion, or sexual identity and
 orientation.
 
 Respectful Communication

--- a/docs/CODE_OF_CONDUCT.rst
+++ b/docs/CODE_OF_CONDUCT.rst
@@ -32,4 +32,6 @@ Constructive Criticism
 Feedback is essential for the growth and improvement of XRTpy. We encourage everyone to provide and receive feedback in a constructive manner.
 Constructive criticism should be aimed at improving the project and fostering learning. We focus on what is best for the overall community, not just for us as individuals.
 
-This Code of Conduct is adapted from the Contributor Covenant, version 2.1, available at https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.
+This Code of Conduct is adapted from the `Contributor Covenant`_, version 2.1.
+
+.. _Contributor Covenant : https://www.contributor-covenant.org/version/2/1/code_of_conduct.html

--- a/docs/CODE_OF_CONDUCT.rst
+++ b/docs/CODE_OF_CONDUCT.rst
@@ -6,15 +6,20 @@
 Code of Conduct
 *******************
 
-XRTpy follows the Contributor Covenant Code of Conduct, which is a widely adopted standard for fostering an inclusive 
-and respectful community. Below are the key principles and standards that all contributors and community members are 
+XRTpy follows the Contributor Covenant Code of Conduct, which is a widely adopted standard for fostering an inclusive
+and respectful community. Below are the key principles and standards that all contributors and community members are
 expected to adhere to.
 
 Our Pledge
 ==========
-We, as contributors and maintainers of XRTpy, pledge to make participation in our project and community a harassment-free 
-experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of 
-experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and 
+We, as contributors and maintainers of XRTpy, pledge to make participation in our project and community a harassment-free
+experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of
+experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and
 orientation.
+
+Respectful Communication
+=========================
+We expect all participants to communicate respectfully and constructively. This includes being polite, considerate, and welcoming,
+while avoiding any form of harassment, discrimination, or offensive behavior.
 
 This Code of Conduct is adapted from the Contributor Covenant, version 2.1, available at https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.

--- a/docs/CODE_OF_CONDUCT.rst
+++ b/docs/CODE_OF_CONDUCT.rst
@@ -2,18 +2,19 @@
 
 .. _CODE_OF_CONDUCT:
 
-***********************
-XRTpy Code of Conduct
-***********************
+*******************
+Code of Conduct
+*******************
+
+XRTpy follows the Contributor Covenant Code of Conduct, which is a widely adopted standard for fostering an inclusive 
+and respectful community. Below are the key principles and standards that all contributors and community members are 
+expected to adhere to.
 
 Our Pledge
 ==========
-Our Pledge 
+We, as contributors and maintainers of XRTpy, pledge to make participation in our project and community a harassment-free 
+experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of 
+experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and 
+orientation.
 
-Standard
-========
-Standard
-
-Guidelines
-==========
-Guidelines
+This Code of Conduct is adapted from the Contributor Covenant, version 2.1, available at https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.

--- a/docs/CODE_OF_CONDUCT.rst
+++ b/docs/CODE_OF_CONDUCT.rst
@@ -39,6 +39,10 @@ If unresolved, project maintainers will mediate to ensure a fair resolution. Vio
 in appropriate consequences, including warnings, temporary bans, or permanent removal. Community leaders are responsible for
 enforcing these rules and taking corrective action as needed.
 
+**Enforcement and Reporting**
+- Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at xrtpy@cfa.harvard.edu. All complaints will be reviewed and investigated promptly and fairly.
+- Community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
 This Code of Conduct is adapted from the `Contributor Covenant`_, version 2.1.
 
 .. _Contributor Covenant : https://www.contributor-covenant.org/version/2/1/code_of_conduct.html

--- a/docs/CODE_OF_CONDUCT.rst
+++ b/docs/CODE_OF_CONDUCT.rst
@@ -6,8 +6,6 @@
 XRTpy Code of Conduct
 ********************
 
-XRTpy CODE_OF_CONDUC
-
 Our Pledge
 ==========
 Our Pledge

--- a/docs/CODE_OF_CONDUCT.rst
+++ b/docs/CODE_OF_CONDUCT.rst
@@ -2,13 +2,13 @@
 
 .. _CODE_OF_CONDUCT:
 
-********************
+***********************
 XRTpy Code of Conduct
-********************
+***********************
 
 Our Pledge
 ==========
-Our Pledge
+Our Pledge 
 
 Standard
 ========

--- a/docs/CODE_OF_CONDUCT.rst
+++ b/docs/CODE_OF_CONDUCT.rst
@@ -30,7 +30,7 @@ regardless of gender, disability, ethnicity, religion, nationality, sexual orien
 Constructive Criticism
 =========================
 Feedback is essential for the growth and improvement of XRTpy. We encourage everyone to provide and receive feedback in a constructive manner.
-Constructive criticism should be aimed at improving the project and fostering learning. We focus on what is best for the overall community, not just for us as individuals.
+Criticism should focus on improving the project and fostering learning, with an emphasis on what is best for the overall community.
 
 Conflict Resolution and Enforcement
 =====================================
@@ -43,6 +43,7 @@ enforcing these rules and taking corrective action as needed.
 
 - Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at xrtpy@cfa.harvard.edu. All complaints will be reviewed and investigated promptly and fairly.
 - Community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
 
 This Code of Conduct is adapted from the `Contributor Covenant`_, version 2.1.
 

--- a/docs/CODE_OF_CONDUCT.rst
+++ b/docs/CODE_OF_CONDUCT.rst
@@ -9,8 +9,8 @@ XRTpy Code of Conduct
 XRTpy CODE_OF_CONDUC
 
 Our Pledge
-========--
-We appreciate any feedback describing your experience using XRTpy. We welcome other methods and ideas towards the development of XRTpy. You may contact us via `email`_ or through `GitHub Hinode XRT`_.
+==========
+Our Pledge
 
 Standard
 ========

--- a/docs/CODE_OF_CONDUCT.rst
+++ b/docs/CODE_OF_CONDUCT.rst
@@ -1,0 +1,21 @@
+.. currentmodule:: xrtpy
+
+.. _CODE_OF_CONDUCT:
+
+********************
+XRTpy Code of Conduct
+********************
+
+XRTpy CODE_OF_CONDUC
+
+Our Pledge
+========--
+We appreciate any feedback describing your experience using XRTpy. We welcome other methods and ideas towards the development of XRTpy. You may contact us via `email`_ or through `GitHub Hinode XRT`_.
+
+Standard
+========
+Standard
+
+Guidelines
+==========
+Guidelines

--- a/docs/CODE_OF_CONDUCT.rst
+++ b/docs/CODE_OF_CONDUCT.rst
@@ -22,4 +22,14 @@ Respectful Communication
 We expect all participants to communicate respectfully and constructively. This includes being polite, considerate, and welcoming,
 while avoiding any form of harassment, discrimination, or offensive behavior.
 
+Diversity and Inclusion
+=========================
+XRTpy values diversity and is dedicated to creating an inclusive environment. We welcome contributions from people of all backgrounds, 
+regardless of gender, disability, ethnicity, religion, nationality, sexual orientation, or any other characteristic.
+
+Constructive Criticism
+=========================
+Feedback is essential for the growth and improvement of XRTpy. We encourage everyone to provide and receive feedback in a constructive manner.
+Constructive criticism should be aimed at improving the project and fostering learning. We focus on what is best for the overall community, not just for us as individuals.
+
 This Code of Conduct is adapted from the Contributor Covenant, version 2.1, available at https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.

--- a/docs/CODE_OF_CONDUCT.rst
+++ b/docs/CODE_OF_CONDUCT.rst
@@ -24,13 +24,19 @@ while avoiding any form of harassment, discrimination, or offensive behavior.
 
 Diversity and Inclusion
 =========================
-XRTpy values diversity and is dedicated to creating an inclusive environment. We welcome contributions from people of all backgrounds, 
+XRTpy values diversity and is dedicated to creating an inclusive environment. We welcome contributions from people of all backgrounds,
 regardless of gender, disability, ethnicity, religion, nationality, sexual orientation, or any other characteristic.
 
 Constructive Criticism
 =========================
 Feedback is essential for the growth and improvement of XRTpy. We encourage everyone to provide and receive feedback in a constructive manner.
 Constructive criticism should be aimed at improving the project and fostering learning. We focus on what is best for the overall community, not just for us as individuals.
+
+Conflict Resolution and Enforcement
+=====================================
+Conflicts are inevitable in any collaborative environment. When they arise, participants are expected to engage in discussions with respect and an open mind. If a conflict cannot be resolved amicably, project maintainers will mediate to ensure a fair and respectful resolution. We are committed to resolving conflicts quickly and fairly, maintaining harmony within the community.
+Violations of this Code of Conduct will not be tolerated. The consequences for such behavior may include warnings, temporary bans, or permanent removal from the project. Community leaders are responsible for enforcing these rules and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
 
 This Code of Conduct is adapted from the `Contributor Covenant`_, version 2.1.
 

--- a/docs/CODE_OF_CONDUCT.rst
+++ b/docs/CODE_OF_CONDUCT.rst
@@ -34,9 +34,10 @@ Constructive criticism should be aimed at improving the project and fostering le
 
 Conflict Resolution and Enforcement
 =====================================
-Conflicts are inevitable in any collaborative environment. When they arise, participants are expected to engage in discussions with respect and an open mind. If a conflict cannot be resolved amicably, project maintainers will mediate to ensure a fair and respectful resolution. We are committed to resolving conflicts quickly and fairly, maintaining harmony within the community.
-Violations of this Code of Conduct will not be tolerated. The consequences for such behavior may include warnings, temporary bans, or permanent removal from the project. Community leaders are responsible for enforcing these rules and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
-
+Conflicts may arise in any collaborative environment. Participants should engage respectfully and with an open mind.
+If unresolved, project maintainers will mediate to ensure a fair resolution. Violations of this Code of Conduct will result
+in appropriate consequences, including warnings, temporary bans, or permanent removal. Community leaders are responsible for
+enforcing these rules and taking corrective action as needed.
 
 This Code of Conduct is adapted from the `Contributor Covenant`_, version 2.1.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -27,6 +27,7 @@ for the analysis of observations made by the `X-Ray Telescope`_ (XRT)
    glossary
    changelog/index
    feedback_communication
+   CODE_OF_CONDUCT
    contributing/index
 
 Indices and tables


### PR DESCRIPTION
Creating a Code of Conduct for the XRTpy project. The Code of Conduct is adapted from the Contributor Covenant (https://www.contributor-covenant.org/) and is designed to foster a welcoming and inclusive community for all contributors and users of XRTpy.  Addresses and resolves the issues discussed in Issue #10  - Add a Code of Conduct. Furthermore, a step towards meeting the requirements to become a SunPy-affiliated package, as outlined in [sunpy/sunpy.org issue #431](https://github.com/sunpy/sunpy.org/issues/431).