### PR TITLE
Remove requirements.txt

### DIFF
--- a/docs/contributing/installation_for_development.rst
+++ b/docs/contributing/installation_for_development.rst
@@ -13,11 +13,7 @@ To set up your development environment:
       git clone https://github.com/HinodeXRT/xrtpy.git`
       cd xrtpy
 
-2. Install the required dependencies::
-
-      pip install -r requirements.txt
-
-3. Install the package in editable mode::
+2. Install the package in editable mode::
 
       pip install -e .
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,0 @@
-# all dependencies required to build, run, test, and document xrtpy
-# * look to the specific requirements/*.txt for specific needs
-# * this will mimic `pip install xrtpy[developer]` (excluding xrtpy)
--r requirements/build.txt
--r requirements/install.txt
--r requirements/tests.txt
--r requirements/docs.txt
--r requirements/extras.txt


### PR DESCRIPTION
In some pull requests earlier to consolidate requirements in `pyproject.toml`, I ended up removing the requirements directory but not `requirements.txt`.  This PR finishes what I started, and removes `requirements.txt` since it is no longer used in CI.  