### PR TITLE
Drop support for Python 3.9

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -41,14 +41,14 @@ jobs:
           noxenv: tests-3.10
           python: '3.10'
 
-        - name: Tests, Python 3.9, Windows
-          os: windows-latest
-          python: 3.9
-          noxenv: tests-3.9
+        - name: Tests, Python 3.10, Linux
+          os: ubuntu-latest
+          noxenv: tests-3.10
+          python: '3.10'
 
-        - name: Import XRTpy, Python 3.9, Windows
-          os: windows-latest
-          python: 3.9
+        - name: Import XRTpy, Python 3.10, Linux
+          os: ubuntu-latest
+          python: 3.10
           noxenv: import_package
 
     steps:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -48,7 +48,7 @@ jobs:
 
         - name: Import XRTpy, Python 3.10, Linux
           os: ubuntu-latest
-          python: 3.10
+          python: '3.10'
           noxenv: import_package
 
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -138,6 +138,7 @@ dmypy.json
 version.py
 .idea
 .vscode
+.history
 .\#*
 
 #ignore mac files

--- a/noxfile.py
+++ b/noxfile.py
@@ -2,7 +2,7 @@ import nox
 
 nox.options.sessions = ["tests", "linters"]
 
-python_versions = ("3.9", "3.10", "3.11", "3.12")
+python_versions = ("3.10", "3.11", "3.12")
 
 sphinx_paths = ["docs", "docs/_build/html"]
 sphinx_fail_on_warnings = ["-W", "--keep-going"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,6 @@ classifiers = [
   "License :: OSI Approved :: BSD License",
   "Operating System :: OS Independent",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
@@ -28,7 +27,7 @@ classifiers = [
 ]
 # SPEC 0 recommends that packages in the scientific pythoniverse support
 # versions of Python that have been released in the last ≤36 months
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dynamic = ["version"]
 authors = [
   {name = "Joy Velasquez", email = "joy.velasquez@cfa.harvard.edu"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,7 @@ Issues = "https://github.com/HinodeXRT/xrtpy/issues"
 Changelog = "https://xrtpy.readthedocs.io/en/stable/changelog/index.html"
 
 [tool.ruff]
-target-version = "py39"
+target-version = "py310"
 show-fixes = true
 extend-exclude = [
   ".jupyter",

--- a/xrtpy/image_correction/tests/test_remove_lightleak.py
+++ b/xrtpy/image_correction/tests/test_remove_lightleak.py
@@ -42,7 +42,7 @@ def get_composite_data_files():
 composite_filenames = get_composite_data_files()
 
 # Using zip as an iterator to pair the data files together. Trouble-free method to use in pytest-parametrize
-data_files = list(zip(IDL_filenames, composite_filenames))
+data_files = list(zip(IDL_filenames, composite_filenames, strict=False))
 
 
 @pytest.mark.parametrize(("idlfile", "compfile"), data_files)


### PR DESCRIPTION
The proposed community standard in [SPEC 0](https://scientific-python.org/specs/spec-0000/) is that versions of Python released in the last three years should be supported by the scientific Pythoniverse.  Python 3.9 was released almost four years ago, so we can drop XRTpy support for it.