### PR TITLE
Remove use of deprecated `pkg_resources`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,12 +23,12 @@ repos:
   - id: check-yaml
 
 - repo: https://github.com/python-jsonschema/check-jsonschema
-  rev: 0.29.0
+  rev: 0.29.2
   hooks:
   - id: check-github-workflows
 
 - repo: https://github.com/sirosen/texthooks
-  rev: 0.6.6
+  rev: 0.6.7
   hooks:
   - id: fix-smartquotes
   - id: fix-spaces
@@ -79,7 +79,7 @@ repos:
     exclude: .*\.fits
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.5.4
+  rev: v0.6.3
   hooks:
   - id: ruff
     name: ruff (see https://docs.astral.sh/ruff/rules)
@@ -96,7 +96,7 @@ repos:
     - black==24.1.1
 
 - repo: https://github.com/nbQA-dev/nbQA
-  rev: 1.8.5
+  rev: 1.8.7
   hooks:
   - id: nbqa-check-ast
     name: validate Python notebooks

--- a/docs/notebooks/data_analysis/Remove_lightleak.ipynb
+++ b/docs/notebooks/data_analysis/Remove_lightleak.ipynb
@@ -31,7 +31,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from pathlib import Path"
+    "from pathlib import Path\n",
+    "\n",
+    "import sunpy.map"
    ]
   },
   {
@@ -41,8 +43,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import pkg_resources\n",
-    "import sunpy.map\n",
+    "from astropy.utils.data import get_pkg_data_path\n",
     "\n",
     "from xrtpy.image_correction.remove_lightleak import remove_lightleak"
    ]
@@ -62,9 +63,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "directory = pkg_resources.resource_filename(\n",
-    "    \"xrtpy\", \"image_correction/data/example_data\"\n",
-    ")\n",
+    "directory = get_pkg_data_path(\"example_data\", package=\"xrtpy.image_correction.data\")\n",
     "data_file = Path(directory) / \"comp_XRT20150621_055911.7.fits\"\n",
     "\n",
     "print(\"File used:\\n\", data_file.name)"

--- a/xrtpy/image_correction/tests/test_deconvolve.py
+++ b/xrtpy/image_correction/tests/test_deconvolve.py
@@ -32,7 +32,7 @@ def data_dir():
         ),
     ],
 )
-def test_unbinned(data_dir, observed_file, idl_file, rtol, atol):
+def test_deconvolve(data_dir, observed_file, idl_file, rtol, atol):
     """
     Test deconvolution against IDL results for binned and unbinned cases
     """

--- a/xrtpy/image_correction/tests/test_deconvolve.py
+++ b/xrtpy/image_correction/tests/test_deconvolve.py
@@ -8,7 +8,7 @@ from sunpy.map import Map
 from xrtpy.image_correction.deconvolve import deconvolve
 
 
-@pytest.fixture()
+@pytest.fixture
 def data_dir():
     return Path(get_pkg_data_path("data", package="xrtpy.image_correction.tests"))
 

--- a/xrtpy/image_correction/tests/test_deconvolve.py
+++ b/xrtpy/image_correction/tests/test_deconvolve.py
@@ -1,66 +1,42 @@
 from pathlib import Path
 
 import numpy as np
-import pkg_resources
+import pytest
+from astropy.utils.data import get_pkg_data_path
 from sunpy.map import Map
 
 from xrtpy.image_correction.deconvolve import deconvolve
 
-test_file = "L1_XRT20120605_215839.9.fits"
-idl_result_file = "L1_XRT20120605_215839.9.deconv.fits"
-test_file_binned = "L1_XRT20210730_175810.1.fits"
-idl_result_file_binned = "L1_XRT20210730_175810.1_deconv.fits"
+
+@pytest.fixture()
+def data_dir():
+    return Path(get_pkg_data_path("data", package="xrtpy.image_correction.tests"))
 
 
-def get_observed_data():
-    directory = pkg_resources.resource_filename("xrtpy", "image_correction/tests/data")
-    data_file = Path(directory) / test_file
-
-    return data_file
-
-
-def get_IDL_results_data():
-    directory = pkg_resources.resource_filename("xrtpy", "image_correction/tests/data")
-    results_file = Path(directory) / idl_result_file
-
-    return results_file
-
-
-def get_observed_binned_data():
-    directory = pkg_resources.resource_filename("xrtpy", "image_correction/tests/data")
-    data_file = Path(directory) / test_file_binned
-
-    return data_file
-
-
-def get_IDL_results_binned_data():
-    directory = pkg_resources.resource_filename("xrtpy", "image_correction/tests/data")
-    results_file = Path(directory) / idl_result_file_binned
-
-    return results_file
-
-
-def test_unbinned():
+@pytest.mark.parametrize(
+    ("observed_file", "idl_file", "atol", "rtol"),
+    [
+        (
+            "L1_XRT20120605_215839.9.fits",
+            "L1_XRT20120605_215839.9.deconv.fits",
+            0,
+            1e-7,
+        ),
+        # Case where image is binned, i.e. has chip_sum = 2
+        # Needs higher tolerances because the binned PSF for the IDL and python codes don't match
+        (
+            "L1_XRT20210730_175810.1.fits",
+            "L1_XRT20210730_175810.1_deconv.fits",
+            4.1,
+            0.008,
+        ),
+    ],
+)
+def test_unbinned(data_dir, observed_file, idl_file, rtol, atol):
     """
-    Test case where the image is at full resolution, i.e. chip_sum = 1
+    Test deconvolution against IDL results for binned and unbinned cases
     """
-    test_data = get_observed_data()
-    in_map = Map(test_data)
-    IDL_result_image = get_IDL_results_data()
-    IDL_result = Map(IDL_result_image)
+    in_map = Map(data_dir / observed_file)
+    IDL_result = Map(data_dir / idl_file)
     out_map = deconvolve(in_map)
-    assert np.allclose(out_map.data, IDL_result.data, atol=1.0e-7)
-
-
-def test_binned():
-    """
-    Test case where the image is binned, i.e. has chip_sum = 2
-    This case needs higher tolerances (atol, rtol) because the binned PSF for
-    the IDL and python codes don't match
-    """
-    test_data = get_observed_binned_data()
-    in_map = Map(test_data)
-    IDL_result_image = get_IDL_results_binned_data()
-    IDL_result = Map(IDL_result_image)
-    out_map = deconvolve(in_map)
-    assert np.allclose(out_map.data, IDL_result.data, atol=4.1, rtol=0.008)
+    assert np.allclose(out_map.data, IDL_result.data, rtol=rtol, atol=atol)

--- a/xrtpy/image_correction/tests/test_deconvolve.py
+++ b/xrtpy/image_correction/tests/test_deconvolve.py
@@ -23,7 +23,7 @@ def data_dir():
             1e-7,
         ),
         # Case where image is binned, i.e. has chip_sum = 2
-        # Needs higher tolerances because the binned PSF for the IDL and python codes don't match
+        # Needs higher tolerances because the binned PSF for the IDL and Python codes don't match
         (
             "L1_XRT20210730_175810.1.fits",
             "L1_XRT20210730_175810.1_deconv.fits",


### PR DESCRIPTION
Fixes #238 

This also reorganizes and simplifies the deconvolution tests.