### PR TITLE
Apply `sphinx_toolbox.installation` to automatically add installation instructions

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -46,6 +46,7 @@ extensions = [
     "sphinx_copybutton",
     "sphinx_codeautolink",
     "sphinx.ext.viewcode",
+    "sphinx_toolbox.installation",
 ]
 
 bibtex_bibfiles = ["bibliography.bib"]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -46,6 +46,7 @@ extensions = [
     "sphinx_copybutton",
     "sphinx_codeautolink",
     "sphinx.ext.viewcode",
+    "sphinx_toolbox.github",
     "sphinx_toolbox.installation",
 ]
 
@@ -222,6 +223,8 @@ for epilog_file in ["_links.rst", "_substitutions.rst"]:
 # Add the nbsphinx_allow_errors option
 nbsphinx_allow_errors = True
 
+github_username = 'HinodeXRT'
+github_repository = 'xrtpy'
 
 def setup(app: Sphinx) -> None:
     app.add_config_value("revision", "", True)  # noqa: FBT003

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -207,6 +207,13 @@ will be installed.
    be improved or have become out of date, please create an issue on
    `XRTpy's GitHub repository`_. It would really help!
 
+
+.. installation:: sphinx-toolbox
+    :pypi:
+    :anaconda:
+    :conda-channels: conda-forge
+    :github:
+
 .. _Anaconda Navigator: https://www.anaconda.com/products/individual
 .. _clone a repository using SSH: https://docs.github.com/en/get-started/getting-started-with-git/about-remote-repositories#cloning-with-ssh-urls
 .. _conda-forge: https://conda-forge.org

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,7 @@ docs = [
   "sphinx-gallery >= 0.16.0",
   "sphinx-hoverxref >= 1.4.0",
   "sphinx-issues >= 4.1.0",
+  "sphinx-toolbox >= 3.8.0",
   "sphinx_automodapi >= 0.17.0",
   "sphinx_rtd_theme >= 2.0.0",
   "sphinxcontrib-bibtex >= 2.6.2",


### PR DESCRIPTION
This experimental PR enables [`sphinx_toolbox.installation`](https://sphinx-toolbox.readthedocs.io/en/stable/extensions/installation.html), which is a Sphinx extension that allows us to automatically include robust installation instructions from PyPI, conda-forge, etc.  This will eliminate the need to maintain our own installation instructions.

It also enables [`sphinx_toolbox.github`](https://sphinx-toolbox.readthedocs.io/en/stable/extensions/github.html) so that we can include how to install XRTpy from GitHub.  (There's a chance that this will overlap with another extension.)