### PR TITLE
Update effective_area.ipynb

### DIFF
--- a/docs/notebooks/computing_functions/effective_area.ipynb
+++ b/docs/notebooks/computing_functions/effective_area.ipynb
@@ -181,7 +181,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We will utilize the `channel_wavelength` property within the Effective_Area_Fundamental object to get the wavelengths. "
+    "We will utilize the `wavelength` property within the Effective_Area_Fundamental object to get the wavelengths. "
    ]
   },
   {
@@ -191,7 +191,7 @@
    "outputs": [],
    "source": [
     "# Wavelength unit in Angstroms A˚\n",
-    "wavelength = Effective_Area_Fundamental.channel_wavelength"
+    "wavelength = Effective_Area_Fundamental.wavelength"
    ]
   },
   {


### PR DESCRIPTION
Property channel_wavelength of the EffectiveAreaFundamental class was changed to simply wavelength. This change is now implemented in this notebook.