### PR TITLE
Update Remove_lightleak.ipynb

### DIFF
--- a/docs/notebooks/data_analysis/Remove_lightleak.ipynb
+++ b/docs/notebooks/data_analysis/Remove_lightleak.ipynb
@@ -63,7 +63,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "directory = get_pkg_data_path(\"example_data\", package=\"xrtpy.image_correction.data\")\n",
+    "directory = get_pkg_data_path(\"data\",\"example_data\", package=\"xrtpy.image_correction\")\n",
     "data_file = Path(directory) / \"comp_XRT20150621_055911.7.fits\"\n",
     "\n",
     "print(\"File used:\\n\", data_file.name)"

--- a/docs/notebooks/data_analysis/Remove_lightleak.ipynb
+++ b/docs/notebooks/data_analysis/Remove_lightleak.ipynb
@@ -63,7 +63,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "directory = get_pkg_data_path(\"data\",\"example_data\", package=\"xrtpy.image_correction\")\n",
+    "directory = get_pkg_data_path(\"data\", \"example_data\", package=\"xrtpy.image_correction\")\n",
     "data_file = Path(directory) / \"comp_XRT20150621_055911.7.fits\"\n",
     "\n",
     "print(\"File used:\\n\", data_file.name)"


### PR DESCRIPTION
Fixed call to get_pkg_data_path. The directory xrtpy.image_correction.data does not have an __init__.py in it, so the package argument needs to be xrtpy.image correction. Then the desired directory can be returned by giving the arguments "data" and "example_data", which are then joined with the xrtpy/image_correction path. The astropy documentation is a bit deceptive on this point.