### PR TITLE
Add comments to explain temperature interpolation in temperature_from_filter_ratio.py

### DIFF
--- a/xrtpy/response/temperature_from_filter_ratio.py
+++ b/xrtpy/response/temperature_from_filter_ratio.py
@@ -460,14 +460,11 @@ def _derive_temperature(
 
     # Performs linear interpolation between two adjacent temperatures in Tmodel,
     # based on the observed filter ratio (`data_ratio`) and the model ratios (`model_ratio`).
-    #
     # `a` and `b` represent differences between the observed and model ratios.
     # The equation weighs the temperatures proportionally, with more weight given
     # to the temperature whose model ratio is closer to the observed filter ratio.
-    #
     # This ensures a smooth transition between temperature values, providing a more
     # accurate estimate when the observed filter ratio lies between two model ratios.
-            
     ok_num[ok_cnt != 1] = 0
     a = np.abs(model_ratio[ok_num] - data_ratio)
     b = np.abs(model_ratio[np.maximum((ok_num - 1), 0)] - data_ratio)

--- a/xrtpy/response/temperature_from_filter_ratio.py
+++ b/xrtpy/response/temperature_from_filter_ratio.py
@@ -458,6 +458,16 @@ def _derive_temperature(
             # pixels are assigned a temperature of 0
             ok_cnt[n] += 1
 
+    # Performs linear interpolation between two adjacent temperatures in Tmodel,
+    # based on the observed filter ratio (`data_ratio`) and the model ratios (`model_ratio`).
+    #
+    # `a` and `b` represent differences between the observed and model ratios.
+    # The equation weighs the temperatures proportionally, with more weight given
+    # to the temperature whose model ratio is closer to the observed filter ratio.
+    #
+    # This ensures a smooth transition between temperature values, providing a more
+    # accurate estimate when the observed filter ratio lies between two model ratios.
+            
     ok_num[ok_cnt != 1] = 0
     a = np.abs(model_ratio[ok_num] - data_ratio)
     b = np.abs(model_ratio[np.maximum((ok_num - 1), 0)] - data_ratio)


### PR DESCRIPTION
Add comments to the temperature_from_filter_ratio.py script to explain the logic behind the temperature interpolation equation. Help clarify the purpose of variables a and b, which represent the differences between the observed and model filter ratios, and describe how the equation ensures smooth temperature transitions by weighing adjacent temperature values proportionally.  Addressing Issue #269 .