### PR TITLE
Fix ReadTheDocs build by adding sphinx.configuration

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -14,7 +14,10 @@ build:
   - graphviz
   jobs:
     post_build:
-    - echo $'\n'For help deciphering documentation build error messages, see:$'\n\n'\ \ https://docs.plasmapy.org/en/latest/contributing/doc_guide.html#troubleshooting
+    - echo $'\n'For help deciphering documentation build error messages, see:$'\n\n'\ \ https://xrtpy.readthedocs.io/en/latest/contributing.html#troubleshooting
+
+sphinx:
+  configuration: docs/conf.py #Feb2025
 
 python:
   install:

--- a/xrtpy/response/temperature_from_filter_ratio.py
+++ b/xrtpy/response/temperature_from_filter_ratio.py
@@ -711,11 +711,8 @@ def make_results_maps(hdr1, hdr2, T_e, EM, T_error, EMerror, extra_metadata):
     for kw in kw_to_copy:
         new_hdr[kw] = hdr1[kw]
     # Ensure CTYPE1 and CTYPE2 use the updated coordinate system
-    new_hdr["CTYPE1"] = "HPLN-TAN"  # Replace 'solar-x' Feb2025
-    new_hdr["CTYPE2"] = "HPLT-TAN"  # Replace 'solar-y' Feb2025
-
-    # new_hdr["L1_file1"] = filename1
-    # new_hdr["L1_file2"] = filename2
+    new_hdr["L1_file1"] = filename1
+    new_hdr["L1_file2"] = filename2
     
     extra_values, extra_comments = split_values_comments(extra_metadata)
     new_hdr.update(extra_values)

--- a/xrtpy/response/temperature_from_filter_ratio.py
+++ b/xrtpy/response/temperature_from_filter_ratio.py
@@ -710,8 +710,13 @@ def make_results_maps(hdr1, hdr2, T_e, EM, T_error, EMerror, extra_metadata):
     ]
     for kw in kw_to_copy:
         new_hdr[kw] = hdr1[kw]
-    new_hdr["L1_file1"] = filename1
-    new_hdr["L1_file2"] = filename2
+    # Ensure CTYPE1 and CTYPE2 use the updated coordinate system
+    new_hdr["CTYPE1"] = "HPLN-TAN"  # Replace 'solar-x' Feb2025
+    new_hdr["CTYPE2"] = "HPLT-TAN"  # Replace 'solar-y' Feb2025
+
+    # new_hdr["L1_file1"] = filename1
+    # new_hdr["L1_file2"] = filename2
+    
     extra_values, extra_comments = split_values_comments(extra_metadata)
     new_hdr.update(extra_values)
     create_date = datetime.now().ctime()


### PR DESCRIPTION
Updating file required by sphinx: The sphinx.configuration key is missing. This key is now required, see the [blog post](https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/) for more information.