### PR TITLE
Allow most recent versions of dependencies to be used in documentation builds

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -95,9 +95,7 @@ def docs(session):
     sphinx_opts = (
         sphinx_paths + sphinx_fail_on_warnings + sphinx_builder + sphinx_nitpicky
     )
-    # The --exclude-newer option is used because using later versions of
-    # SunPy leads to a SunPyDeprecationWarning.
-    session.install(".[docs]", "--exclude-newer=2025-02-20")
+    session.install(".[docs]")
     session.run(
         "sphinx-build",
         *sphinx_opts,

--- a/xrtpy/response/temperature_from_filter_ratio.py
+++ b/xrtpy/response/temperature_from_filter_ratio.py
@@ -710,6 +710,12 @@ def make_results_maps(hdr1, hdr2, T_e, EM, T_error, EMerror, extra_metadata):
     ]
     for kw in kw_to_copy:
         new_hdr[kw] = hdr1[kw]
+    # These are deprecated values for CTYPE1 and CTYPE2
+    # that will not be supported in the future
+    if new_hdr["ctype1"].lower() == "solar-x".lower():
+        new_hdr["ctype1"] = "HPLN-TAN"
+    if new_hdr["ctype2"].lower() == "solar-y".lower():
+        new_hdr["ctype2"] = "HPLT-TAN"
     new_hdr["L1_file1"] = filename1
     new_hdr["L1_file2"] = filename2
     extra_values, extra_comments = split_values_comments(extra_metadata)


### PR DESCRIPTION
In #330, we were getting `SunPyDeprecationWarning`s when using the most recent version of SunPy in documentation builds (see #327).  To temporarily alleviate this, I added an `--exclude-newer` flag that is invoked by `uv` when installing packages for the doc builds. This flag prevents dependency resolutions from including packages that were added after a particular date in the environment.

This PR removes the `--exclude-newer` flag, which will allow the most recent versions of dependencies to be used in the Python environments for documentation builds. The deprecation warning is still happening, so this PR is mostly a placeholder so that we don't forget about it later on.  This PR should only be merged when the documentation build is passing.
