### PR TITLE
Remove sphinx-hoverxref

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -84,7 +84,6 @@ suppress_warnings = [
 # extensions coming with Sphinx (named "sphinx.ext.*") or your custom
 # ones.
 extensions = [
-    "hoverxref.extension",
     "sphinx_automodapi.automodapi",
     "sphinx_automodapi.smart_resolver",
     "sphinx_copybutton",
@@ -191,41 +190,6 @@ intersphinx_mapping = {
     "matplotlib": ("https://matplotlib.org/stable", None),
     "ndcube": ("https://docs.sunpy.org/projects/ndcube/en/stable/", None),
     "sunpy": ("https://docs.sunpy.org/en/stable/", None),
-}
-
-# -- Options for hoverxref -----------------------------------------------------
-
-if os.environ.get("READTHEDOCS"):
-    hoverxref_api_host = "https://readthedocs.org"
-
-    if os.environ.get("PROXIED_API_ENDPOINT"):
-        # Use the proxied API endpoint
-        # A RTD thing to avoid a CSRF block when docs are using a custom domain
-        hoverxref_api_host = "/_"
-
-hoverxref_auto_ref = True
-hoverxref_domains = ["py", "cite"]
-hoverxref_roles = ["confval", "term"]
-hoverxref_mathjax = True
-hoverxref_modal_hover_delay = 500
-hoverxref_tooltip_maxwidth = 600  # RTD main window is 696px
-hoverxref_intersphinx = list(intersphinx_mapping.keys())
-hoverxref_role_types = {
-    # Roles within the py domain
-    "attr": "tooltip",
-    "class": "tooltip",
-    "const": "tooltip",
-    "data": "tooltip",
-    "exc": "tooltip",
-    "func": "tooltip",
-    "meth": "tooltip",
-    "mod": "tooltip",
-    "obj": "tooltip",
-    # Roles within the std domain
-    "confval": "tooltip",
-    "hoverxref": "tooltip",
-    "ref": "tooltip",  # Would be used by hoverxref_auto_ref if we set it to True
-    "term": "tooltip",
 }
 
 # -- Options for HTML output ---------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,6 @@ optional-dependencies.docs = [
   "sphinx-automodapi>=0.17",
   "sphinx-copybutton>=0.5.2",
   "sphinx-gallery>=0.16",
-  "sphinx-hoverxref>=1.4",
   "sphinx-issues>=4.1",
   "sphinxcontrib-bibtex>=2.6.2",
   "sphinxext-opengraph>=0.6",


### PR DESCRIPTION
Despite having the coolest name of a Sphinx extension in the history of the multiverse, [`sphinx-hoverxref`](https://github.com/readthedocs/sphinx-hoverxref) has been deprecated.  😅 This PR removes it as an extension.  

My understanding is that it is being replaced via Read the Docs add-ons, though I haven't looked up the details.

Closes #349.