### PR TITLE
Add documentation for generate_temperature_responses tool in Getting Started guide

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -81,6 +81,63 @@ You may also pass the ``abundance_model`` keyword to ``temperature_from_filter_r
    In the future, XRTpy may support additional emission model libraries beyond CHIANTI.
    This feature is planned for the **v0.6.0** release, expected later in **2025**. Stay tuned for exciting new capabilities!
 
+
+Tools
+*****
+
+The `xrtpy.response.tools` module includes helpful utility functions to streamline workflows. As of version 0.5.0, it includes the following:
+
+Generate Temperature Responses
+------------------------------
+
+Use the ``generate_temperature_responses`` tool to compute the temperature response for one or more filters — including combinations like ``"Al-poly/Ti-poly"`` — with a single command.
+
+This function returns a list of ``TemperatureResponseFundamental`` objects, one for each specified filter.
+
+**Function:**
+
+.. code-block:: python
+
+   from xrtpy.response.tools import generate_temperature_responses
+
+   responses = generate_temperature_responses(
+       filters=["Al-poly", "Be-thick", "Al-poly/Ti-poly"],
+       obs_date="2020-07-04T00:00:00",
+       abundance="Hybrid"
+   )
+
+   for resp in responses:
+       print(f"Filter: {resp.filter_name}")
+       print(f"  Temperatures: {resp.temperature[:3]}")
+       print(f"  Response: {resp.response[:3]}")
+       print()
+
+**Example Output:**
+
+.. code-block:: text
+
+   Filter: Al-poly
+     Temperatures: [100000. 112201.9 125892.516] K
+     Response: [8.34e-31 1.07e-30 1.53e-30] cm5 DN / (pix s)
+
+   Filter: Be-thick
+     Temperatures: [100000. 112201.9 125892.516] K
+     Response: [0.00e+00 1.73e-94 2.43e-84] cm5 DN / (pix s)
+
+   Filter: Al-poly/Ti-poly
+     Temperatures: [100000. 112201.9 125892.516] K
+     Response: [5.34e-34 7.24e-34 1.11e-33] cm5 DN / (pix s)
+
+Each response object has the following attributes:
+
+- ``filter_name`` — Filter label (e.g., ``"Be-thick"`` or ``"Al-poly/Ti-poly"``)
+- ``temperature`` — Temperature grid (Astropy Quantity in K)
+- ``response`` — Temperature response function (Astropy Quantity in cm⁵ DN / (pix s))
+
+This tool is useful on its own, but it also serves as a foundation for upcoming **Differential Emission Measure (DEM)** workflows in XRTpy.
+
+
+
 Data Products
 *************
 


### PR DESCRIPTION
This PR adds a new section under the "Getting Started" guide titled Tools, introducing the generate_temperature_responses utility from xrtpy.response.tools