### PR TITLE
Add changelog and promote fixes for v0.5.1

### DIFF
--- a/docs/changelog/0.5.1.rst
+++ b/docs/changelog/0.5.1.rst
@@ -1,0 +1,16 @@
+.. _changelog-0.5.1:
+
+*************************
+XRTpy 0.5.1 (2026-04-22)
+*************************
+
+Bug Fixes
+---------
+
+- Fixed the temperature response filter(s) method to remove an unnecessary
+  print statement and corrected logger placement in the code. (:pull:`387`)
+
+- Removed older CCD contamination files and updated with files through
+  2026-02-22. (:pull:`386`, :pull:`385`)
+
+- Updated monthly CCD contamination files. (:pull:`382`, :pull:`380`)

--- a/docs/changelog/0.5.1.rst
+++ b/docs/changelog/0.5.1.rst
@@ -8,9 +8,9 @@ Bug Fixes
 ---------
 
 - Fixed the temperature response filter(s) method to remove an unnecessary
-  print statement and corrected logger placement in the code. (:pull:`387`)
+  print statement and corrected logger placement in the code. (:pr:`387`)
 
 - Removed older CCD contamination files and updated with files through
-  2026-02-22. (:pull:`386`, :pull:`385`)
+  2026-02-22. (:pr:`386`, :pr:`385`)
 
-- Updated monthly CCD contamination files. (:pull:`382`, :pull:`380`)
+- Updated monthly CCD contamination files. (:pr:`382`, :pr:`380`)

--- a/docs/changelog/index.rst
+++ b/docs/changelog/index.rst
@@ -9,6 +9,7 @@ This document lists the changes made during each release of XRTpy, including bug
 .. toctree::
    :maxdepth: 1
 
+   0.5.1
    0.5.0
    0.4.0
    0.3.0

--- a/xrtpy/response/temperature_response.py
+++ b/xrtpy/response/temperature_response.py
@@ -3,12 +3,16 @@ __all__ = [
 ]
 
 from pathlib import Path
+import logging
+logger = logging.getLogger(__name__)
 
 import astropy.constants as const
 import numpy as np
 import scipy.io
 from astropy import units as u
 from scipy import interpolate
+
+
 
 from xrtpy.response.channel import Channel
 from xrtpy.response.effective_area import EffectiveAreaFundamental, parse_filter_input
@@ -81,9 +85,8 @@ class TemperatureResponseFundamental:
         self._effective_area_fundamental = EffectiveAreaFundamental(
             filter_name, observation_date
         )
-        print(
-            f"\nFilter1: {self.filter1_name}, Filter2: {self.filter2_name}, Combo: {self.is_combo}\n"
-        )
+        
+        logger.debug(f"Filter1: {self.filter1_name}, Filter2: {self.filter2_name}, Combo: {self.is_combo}")
 
     @property
     def filter_name(self):

--- a/xrtpy/response/temperature_response.py
+++ b/xrtpy/response/temperature_response.py
@@ -2,8 +2,9 @@ __all__ = [
     "TemperatureResponseFundamental",
 ]
 
-from pathlib import Path
 import logging
+from pathlib import Path
+
 logger = logging.getLogger(__name__)
 
 import astropy.constants as const
@@ -11,8 +12,6 @@ import numpy as np
 import scipy.io
 from astropy import units as u
 from scipy import interpolate
-
-
 
 from xrtpy.response.channel import Channel
 from xrtpy.response.effective_area import EffectiveAreaFundamental, parse_filter_input
@@ -85,8 +84,10 @@ class TemperatureResponseFundamental:
         self._effective_area_fundamental = EffectiveAreaFundamental(
             filter_name, observation_date
         )
-        
-        logger.debug(f"Filter1: {self.filter1_name}, Filter2: {self.filter2_name}, Combo: {self.is_combo}")
+
+        logger.debug(
+            f"Filter1: {self.filter1_name}, Filter2: {self.filter2_name}, Combo: {self.is_combo}"
+        )
 
     @property
     def filter_name(self):

--- a/xrtpy/response/temperature_response.py
+++ b/xrtpy/response/temperature_response.py
@@ -5,8 +5,6 @@ __all__ = [
 import logging
 from pathlib import Path
 
-logger = logging.getLogger(__name__)
-
 import astropy.constants as const
 import numpy as np
 import scipy.io
@@ -15,6 +13,8 @@ from scipy import interpolate
 
 from xrtpy.response.channel import Channel
 from xrtpy.response.effective_area import EffectiveAreaFundamental, parse_filter_input
+
+logger = logging.getLogger(__name__)
 
 _abundance_model_file_path = {
     "coronal_abundance_path": Path(__file__).parent.absolute()


### PR DESCRIPTION
## Summary

This PR brings the following merged fixes from the fork into the upstream 
repo and adds the v0.5.1 changelog entry.

## Changes Included

- Fixed temperature response filter(s) method — replaced unnecessary `print` 
  statement with proper `logger.debug` call (#387)
- Removed older CCD contamination files, updated through 2026-02-22 (#386, #385)
- Updated monthly CCD contamination files (#382, #380)
- Added `docs/changelog/0.5.1.rst`
- Updated `docs/changelog/index.rst` to include 0.5.1 at the top

## Purpose

Promotes `latest` documentation to `stable` by tagging `v0.5.1` after this 
merges. The DEM solver (`xrtpy/xrt_dem_iterative/`) is **not** included in 
this release and will be part of the upcoming `v0.6.0`.

## Related

- Closes out the `v0.5.1-pre` pre-release from July 2025
- Next release will be `v0.6.0` which includes the DEM solver