### PR TITLE
Fix expmap shape validation and binning when binfac > 1

### DIFF
--- a/xrtpy/response/temperature_from_filter_ratio.py
+++ b/xrtpy/response/temperature_from_filter_ratio.py
@@ -159,6 +159,20 @@ def temperature_from_filter_ratio(
     data1 = data1.astype(float)
     data2 = data2.astype(float)
 
+    #JOY
+    if expmap1 is not None and np.shape(expmap1) != data1.shape:
+        raise ValueError(
+            f"expmap1 must match map1 shape {data1.shape}; "
+            f"received {np.shape(expmap1)}"
+        )
+    #JOY
+    if expmap2 is not None and np.shape(expmap2) != data2.shape:
+        raise ValueError(
+            f"expmap2 must match map2 shape {data2.shape}; "
+            f"received {np.shape(expmap2)}"
+        )
+
+
     n1 = "XRT_RENORMALIZE" in hdr1["HISTORY"]
     n2 = "XRT_RENORMALIZE" in hdr2["HISTORY"]
     # This allows use of normalized data (contrary to original IDL code):
@@ -188,21 +202,58 @@ def temperature_from_filter_ratio(
     map1 = Map(data1, map1.meta, mask=mask)
     map2 = Map(data2, map2.meta, mask=mask)
 
+    # if binfac > 1:
+    #     map1 = map1.superpixel([binfac, binfac] * u.pix)
+    #     map2 = map2.superpixel([binfac, binfac] * u.pix)
+    #     data1 = map1.data
+    #     data2 = map2.data
+    #     # fix for issue with binning in superpixel - mask not summed
+    #     mask = (
+    #         reshape_image_to_4d_superpixel(mask, [binfac, binfac], [0, 0]).sum(3).sum(1)
+    #     )
+    #     mask = mask.astype(bool)
+    #     map1.mask = mask
+    #     map2.mask = mask
+    #     # binning updates header keywords
+    #     hdr1 = map1.meta
+    #     hdr2 = map2.meta
+    #JOY
     if binfac > 1:
         map1 = map1.superpixel([binfac, binfac] * u.pix)
         map2 = map2.superpixel([binfac, binfac] * u.pix)
         data1 = map1.data
         data2 = map2.data
-        # fix for issue with binning in superpixel - mask not summed
-        mask = (
-            reshape_image_to_4d_superpixel(mask, [binfac, binfac], [0, 0]).sum(3).sum(1)
-        )
+
+        # A superpixel is masked if any contributing pixel is masked.
+        mask = reshape_image_to_4d_superpixel(
+            mask, [binfac, binfac], [0, 0]
+        ).sum(axis=(1, 3))
         mask = mask.astype(bool)
+
+        # Bin exposure maps to match the binned image dimensions. The mean is
+        # required because the emission-measure calculation already accounts
+        # for the number of pixels using binfac**2.
+        if expmap1 is not None:
+            expmap1 = reshape_image_to_4d_superpixel(
+                np.asarray(expmap1),
+                [binfac, binfac],
+                [0, 0],
+            ).mean(axis=(1, 3))
+
+        if expmap2 is not None:
+            expmap2 = reshape_image_to_4d_superpixel(
+                np.asarray(expmap2),
+                [binfac, binfac],
+                [0, 0],
+            ).mean(axis=(1, 3))
+
         map1.mask = mask
         map2.mask = mask
-        # binning updates header keywords
+
+        # Binning updates header keywords.
         hdr1 = map1.meta
         hdr2 = map2.meta
+
     # input mask for data should be False in parts of the images to be used and
     # True in places we want to mask out
     # Here we additionally mask out pixels in which the data in either image

--- a/xrtpy/response/temperature_from_filter_ratio.py
+++ b/xrtpy/response/temperature_from_filter_ratio.py
@@ -159,19 +159,17 @@ def temperature_from_filter_ratio(
     data1 = data1.astype(float)
     data2 = data2.astype(float)
 
-    #JOY
     if expmap1 is not None and np.shape(expmap1) != data1.shape:
         raise ValueError(
             f"expmap1 must match map1 shape {data1.shape}; "
             f"received {np.shape(expmap1)}"
         )
-    #JOY
+
     if expmap2 is not None and np.shape(expmap2) != data2.shape:
         raise ValueError(
             f"expmap2 must match map2 shape {data2.shape}; "
             f"received {np.shape(expmap2)}"
         )
-
 
     n1 = "XRT_RENORMALIZE" in hdr1["HISTORY"]
     n2 = "XRT_RENORMALIZE" in hdr2["HISTORY"]
@@ -202,22 +200,6 @@ def temperature_from_filter_ratio(
     map1 = Map(data1, map1.meta, mask=mask)
     map2 = Map(data2, map2.meta, mask=mask)
 
-    # if binfac > 1:
-    #     map1 = map1.superpixel([binfac, binfac] * u.pix)
-    #     map2 = map2.superpixel([binfac, binfac] * u.pix)
-    #     data1 = map1.data
-    #     data2 = map2.data
-    #     # fix for issue with binning in superpixel - mask not summed
-    #     mask = (
-    #         reshape_image_to_4d_superpixel(mask, [binfac, binfac], [0, 0]).sum(3).sum(1)
-    #     )
-    #     mask = mask.astype(bool)
-    #     map1.mask = mask
-    #     map2.mask = mask
-    #     # binning updates header keywords
-    #     hdr1 = map1.meta
-    #     hdr2 = map2.meta
-    #JOY
     if binfac > 1:
         map1 = map1.superpixel([binfac, binfac] * u.pix)
         map2 = map2.superpixel([binfac, binfac] * u.pix)
@@ -225,9 +207,9 @@ def temperature_from_filter_ratio(
         data2 = map2.data
 
         # A superpixel is masked if any contributing pixel is masked.
-        mask = reshape_image_to_4d_superpixel(
-            mask, [binfac, binfac], [0, 0]
-        ).sum(axis=(1, 3))
+        mask = reshape_image_to_4d_superpixel(mask, [binfac, binfac], [0, 0]).sum(
+            axis=(1, 3)
+        )
         mask = mask.astype(bool)
 
         # Bin exposure maps to match the binned image dimensions. The mean is

--- a/xrtpy/response/temperature_from_filter_ratio.py
+++ b/xrtpy/response/temperature_from_filter_ratio.py
@@ -161,14 +161,12 @@ def temperature_from_filter_ratio(
 
     if expmap1 is not None and np.shape(expmap1) != data1.shape:
         raise ValueError(
-            f"expmap1 must match map1 shape {data1.shape}; "
-            f"received {np.shape(expmap1)}"
+            f"expmap1 must match map1 shape {data1.shape}; received {np.shape(expmap1)}"
         )
 
     if expmap2 is not None and np.shape(expmap2) != data2.shape:
         raise ValueError(
-            f"expmap2 must match map2 shape {data2.shape}; "
-            f"received {np.shape(expmap2)}"
+            f"expmap2 must match map2 shape {data2.shape}; received {np.shape(expmap2)}"
         )
 
     n1 = "XRT_RENORMALIZE" in hdr1["HISTORY"]

--- a/xrtpy/response/temperature_from_filter_ratio.py
+++ b/xrtpy/response/temperature_from_filter_ratio.py
@@ -95,10 +95,13 @@ def temperature_from_filter_ratio(
     expmap1 : numpy array [Optional]
         if provided, gives exposure time (s) for each pixel in image 1. This
         is useful for composite images in which different parts of the image
-        have different exposure times
+        have different exposure times. Must have the same shape as image 1.
+        If ``binfac`` > 1, the exposure map is binned internally to match the
+        binned image, so it should be given at the original (unbinned) size.
 
     expmap2 : numpy array [Optional]
-        if provided, gives exposure time (s) for each pixel in image 2.
+        if provided, gives exposure time (s) for each pixel in image 2. The
+        same requirements apply as for ``expmap1``.
 
     Returns:
     --------

--- a/xrtpy/response/tests/test_temperature_from_filter_ratio.py
+++ b/xrtpy/response/tests/test_temperature_from_filter_ratio.py
@@ -148,6 +148,7 @@ def test_binning_case():
         10.0 ** EMerr.data[goodE], 10.0 ** idlEMerr[goodE], atol=2.0e43, rtol=0.03
     )
 
+
 def test_expmap_shape_mismatch_raises():
     """
     Test that an exposure map whose shape does not match its image raises a
@@ -174,7 +175,8 @@ def test_expmap_shape_mismatch_raises():
         temperature_from_filter_ratio(
             map1, map2, expmap1=good_expmap1, expmap2=bad_expmap
         )
-        
+
+
 def test_expmap_with_binfac_matches_scalar_exptime():
     """
     Test that a uniform exposure map combined with binning gives the same

--- a/xrtpy/response/tests/test_temperature_from_filter_ratio.py
+++ b/xrtpy/response/tests/test_temperature_from_filter_ratio.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 import numpy as np
+import pytest
 import sunpy.map
 from scipy.io import readsav
 
@@ -147,7 +148,33 @@ def test_binning_case():
         10.0 ** EMerr.data[goodE], 10.0 ** idlEMerr[goodE], atol=2.0e43, rtol=0.03
     )
 
+def test_expmap_shape_mismatch_raises():
+    """
+    Test that an exposure map whose shape does not match its image raises a
+    clear ValueError up front, rather than failing later with a confusing
+    broadcasting error.
+    """
 
+    data_files = get_observed_data()
+    file1 = data_files[1]
+    file2 = data_files[0]
+    map1 = sunpy.map.Map(file1)
+    map2 = sunpy.map.Map(file2)
+
+    good_expmap1 = np.full(map1.data.shape, map1.meta["EXPTIME"])
+    good_expmap2 = np.full(map2.data.shape, map2.meta["EXPTIME"])
+    bad_expmap = np.full((10, 10), 1.0)
+
+    with pytest.raises(ValueError, match="expmap1 must match map1 shape"):
+        temperature_from_filter_ratio(
+            map1, map2, expmap1=bad_expmap, expmap2=good_expmap2
+        )
+
+    with pytest.raises(ValueError, match="expmap2 must match map2 shape"):
+        temperature_from_filter_ratio(
+            map1, map2, expmap1=good_expmap1, expmap2=bad_expmap
+        )
+        
 def test_expmap_with_binfac_matches_scalar_exptime():
     """
     Test that a uniform exposure map combined with binning gives the same

--- a/xrtpy/response/tests/test_temperature_from_filter_ratio.py
+++ b/xrtpy/response/tests/test_temperature_from_filter_ratio.py
@@ -146,3 +146,44 @@ def test_binning_case():
     assert np.allclose(
         10.0 ** EMerr.data[goodE], 10.0 ** idlEMerr[goodE], atol=2.0e43, rtol=0.03
     )
+
+
+def test_expmap_with_binfac_matches_scalar_exptime():
+    """
+    Test that a uniform exposure map combined with binning gives the same
+    result as passing no exposure map at all (which uses the scalar EXPTIME).
+
+    This guards the fix for combining expmap1/expmap2 with binfac > 1, and
+    also catches a change from mean to sum when binning the exposure maps,
+    since that would shift EM by log10(binfac**2).
+    """
+
+    data_files = get_observed_data()
+    file1 = data_files[1]
+    file2 = data_files[0]
+    map1 = sunpy.map.Map(file1)
+    map2 = sunpy.map.Map(file2)
+
+    expmap1 = np.full(map1.data.shape, map1.meta["EXPTIME"])
+    expmap2 = np.full(map2.data.shape, map2.meta["EXPTIME"])
+
+    with_exp = temperature_from_filter_ratio(
+        map1,
+        map2,
+        no_threshold=True,
+        binfac=2,
+        expmap1=expmap1,
+        expmap2=expmap2,
+    )
+    without_exp = temperature_from_filter_ratio(
+        map1,
+        map2,
+        no_threshold=True,
+        binfac=2,
+    )
+
+    expected_shape = (map1.data.shape[0] // 2, map1.data.shape[1] // 2)
+    assert with_exp.Tmap.data.shape == expected_shape
+
+    assert np.allclose(with_exp.Tmap.data, without_exp.Tmap.data)
+    assert np.allclose(with_exp.EMmap.data, without_exp.EMmap.data)


### PR DESCRIPTION
Fixes a bug reported by @kreevescfa - where combining `expmap1`/`expmap2` with `binfac > 1` in `temperature_from_filter_ratio` raises a shape mismatch error:

```
ValueError: operands could not be broadcast together with shapes (512,512) (1024,1024)
```
