### PR TITLE
Add GitHub workflows for PyHC interoperability

### DIFF
--- a/.github/workflows/pyhc-actions.yml
+++ b/.github/workflows/pyhc-actions.yml
@@ -1,0 +1,45 @@
+# Quality assurance checks for the Python in Heliophysics Community.
+#
+# Verify that XRTpy can be installed in PyHC's Python environment,
+# and check that requirements are consistent with the PyHC Python &
+# Upstream Package Support Policy (PHEP 3).
+#
+# Documentation: https://github.com/heliophysicsPy/pyhc-actions
+# PHEP 3: https://github.com/heliophysicsPy/standards/blob/main/pheps/phep-0003.md
+
+name: PyHC Actions
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+  - cron: 0 15 1 1,4,7,10 *
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  phep3-compliance:
+    name: PHEP 3 Compliance
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v7.0.1
+      with:
+        persist-credentials: false
+
+    - name: Check PHEP 3 Compliance
+      uses: heliophysicsPy/pyhc-actions/phep3-compliance@v1.1.1
+      # Use `ignore-errors-for` to allow exceptions to PHEP 3 policy
+
+  pyhc-env-compat:
+    name: PyHC Environment Compatibility
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v7.0.1
+      with:
+        persist-credentials: false
+
+    - name: Check PyHC Environment Compatibility
+      uses: heliophysicsPy/pyhc-actions/pyhc-env-compat@v1.1.1


### PR DESCRIPTION
This PR adds a GitHub workflow file for:

 - Checking to make sure XRTpy can be installed alongside other PyHC packages
 - Requirements are consistent with [PHEP 3](https://github.com/heliophysicsPy/standards/blob/main/pheps/phep-0003.md) (see also [SPEC 0](https://scientific-python.org/specs/spec-0000/))

> [!NOTE]
> Since this PR is adding a new GitHub workflow, we probably need to merge this workflow to make sure that it works.